### PR TITLE
Modernize UI with MudBlazor component library

### DIFF
--- a/src/FaunaFinder.Api/Components/App.razor
+++ b/src/FaunaFinder.Api/Components/App.razor
@@ -6,6 +6,8 @@
     <title>FaunaFinder - Puerto Rico</title>
     <base href="/" />
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="css/app.css" />
     <HeadOutlet @rendermode="InteractiveServer" />
 </head>
@@ -13,6 +15,7 @@
     <Routes @rendermode="InteractiveServer" />
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="js/leafletInterop.js"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 </html>

--- a/src/FaunaFinder.Api/Components/Layout/MainLayout.razor
+++ b/src/FaunaFinder.Api/Components/Layout/MainLayout.razor
@@ -1,23 +1,36 @@
 @inherits LayoutComponentBase
 
-<div class="layout">
-    <header class="header">
-        <div class="header-content">
-            <a href="/" class="logo">
-                <span class="logo-text">FaunaFinder</span>
-            </a>
-            <nav class="nav">
-                <a href="/" class="nav-link">Map</a>
-                <a href="/about" class="nav-link">About</a>
-            </nav>
-        </div>
-    </header>
+<MudThemeProvider Theme="_theme" />
+<MudPopoverProvider />
+<MudDialogProvider />
+<MudSnackbarProvider />
 
-    <main class="main-content">
+<MudLayout>
+    <MudAppBar Color="Color.Primary" Fixed="true" Dense="true">
+        <MudText Typo="Typo.h6" Class="ml-2">FaunaFinder</MudText>
+        <MudSpacer />
+        <MudButton Href="/" Color="Color.Inherit" Variant="Variant.Text">Map</MudButton>
+        <MudButton Href="/about" Color="Color.Inherit" Variant="Variant.Text">About</MudButton>
+    </MudAppBar>
+
+    <MudMainContent Class="pt-14">
         @Body
-    </main>
+    </MudMainContent>
+</MudLayout>
 
-    <footer class="footer">
-        <p>FaunaFinder - Puerto Rico Conservation Species Finder</p>
-    </footer>
-</div>
+@code {
+    private readonly MudTheme _theme = new()
+    {
+        PaletteLight = new PaletteLight
+        {
+            Primary = "#2d6a4f",
+            PrimaryDarken = "#1b4332",
+            PrimaryLighten = "#40916c",
+            Secondary = "#40916c",
+            AppbarBackground = "#2d6a4f",
+            Background = "#f8f9fa",
+            Surface = "#ffffff",
+            DrawerBackground = "#ffffff"
+        }
+    };
+}

--- a/src/FaunaFinder.Api/Components/Pages/About.razor
+++ b/src/FaunaFinder.Api/Components/Pages/About.razor
@@ -2,25 +2,37 @@
 
 <PageTitle>About - FaunaFinder</PageTitle>
 
-<div class="about-page">
-    <h1>About FaunaFinder</h1>
+<MudContainer MaxWidth="MaxWidth.Medium" Class="py-8">
+    <MudText Typo="Typo.h4" Color="Color.Primary" GutterBottom="true">About FaunaFinder</MudText>
 
-    <section class="about-section">
-        <h2>What is FaunaFinder?</h2>
-        <p>
+    <MudPaper Elevation="0" Class="pa-4 mb-4">
+        <MudText Typo="Typo.h6" Color="Color.Primary" GutterBottom="true">What is FaunaFinder?</MudText>
+        <MudText Typo="Typo.body1">
             FaunaFinder is an interactive web application that helps users explore conservation
             information for Puerto Rico's municipalities. Click on any municipality on the map
             to discover the species that inhabit that region, along with relevant NRCS conservation
             practices and FWS action recommendations.
-        </p>
-    </section>
+        </MudText>
+    </MudPaper>
 
-    <section class="about-section">
-        <h2>Data Sources</h2>
-        <ul>
-            <li><strong>NRCS Practices:</strong> Natural Resources Conservation Service conservation practice standards</li>
-            <li><strong>FWS Actions:</strong> U.S. Fish and Wildlife Service recommended conservation actions</li>
-            <li><strong>Species Data:</strong> Species occurrence and habitat information for Puerto Rico</li>
-        </ul>
-    </section>
-</div>
+    <MudPaper Elevation="0" Class="pa-4">
+        <MudText Typo="Typo.h6" Color="Color.Primary" GutterBottom="true">Data Sources</MudText>
+        <MudList T="string" Dense="true">
+            <MudListItem Icon="@Icons.Material.Filled.Agriculture">
+                <MudText Typo="Typo.body1">
+                    <strong>NRCS Practices:</strong> Natural Resources Conservation Service conservation practice standards
+                </MudText>
+            </MudListItem>
+            <MudListItem Icon="@Icons.Material.Filled.Pets">
+                <MudText Typo="Typo.body1">
+                    <strong>FWS Actions:</strong> U.S. Fish and Wildlife Service recommended conservation actions
+                </MudText>
+            </MudListItem>
+            <MudListItem Icon="@Icons.Material.Filled.Map">
+                <MudText Typo="Typo.body1">
+                    <strong>Species Data:</strong> Species occurrence and habitat information for Puerto Rico
+                </MudText>
+            </MudListItem>
+        </MudList>
+    </MudPaper>
+</MudContainer>

--- a/src/FaunaFinder.Api/Components/Pages/Home.razor
+++ b/src/FaunaFinder.Api/Components/Pages/Home.razor
@@ -11,105 +11,135 @@
         <div id="map" class="map"></div>
     </div>
 
-    <aside class="sidebar open">
+    <MudDrawer Open="true" Anchor="Anchor.End" Variant="DrawerVariant.Persistent" Width="360px" Elevation="2" Class="sidebar-drawer">
         @if (LoadMunicipalitySpeciesCommand.IsLoading || LoadAllSpeciesCommand.IsLoading)
         {
-            <div class="loading">
-                <div class="spinner"></div>
-                <p>Loading...</p>
-            </div>
+            <MudContainer Class="d-flex flex-column align-center justify-center" Style="height: 200px;">
+                <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+                <MudText Typo="Typo.body2" Class="mt-3">Loading...</MudText>
+            </MudContainer>
         }
         else if (selectedMunicipality != null)
         {
-            <div class="sidebar-header">
-                <h2>@selectedMunicipality.Name</h2>
-                <button class="close-btn" @onclick="ShowAllSpecies">← All Species</button>
-            </div>
+            <MudPaper Class="pa-3 mud-theme-primary" Square="true" Elevation="0">
+                <div class="d-flex justify-space-between align-center">
+                    <MudText Typo="Typo.subtitle1">@selectedMunicipality.Name</MudText>
+                    <MudButton Variant="Variant.Text" Color="Color.Inherit" Size="Size.Small" OnClick="ShowAllSpecies">
+                        ← All Species
+                    </MudButton>
+                </div>
+            </MudPaper>
 
-            <div class="sidebar-content">
+            <MudContainer Class="pa-3" MaxWidth="MaxWidth.False">
                 @if (species.Count == 0)
                 {
-                    <p class="no-data">No species data available for this municipality.</p>
+                    <MudAlert Severity="Severity.Info" Variant="Variant.Text">
+                        No species data available for this municipality.
+                    </MudAlert>
                 }
                 else
                 {
-                    <p class="species-count">@species.Count species found</p>
-                    <div class="species-list">
+                    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
+                        @species.Count species found
+                    </MudText>
+
+                    <MudExpansionPanels MultiExpansion="false" Elevation="0">
                         @foreach (var s in species)
                         {
-                            <div class="species-card @(expandedSpeciesId == s.Id ? "expanded" : "")">
-                                <div class="species-header" @onclick="() => ToggleSpecies(s.Id)">
-                                    <div class="species-info">
-                                        <h3 class="species-name">@s.CommonName</h3>
-                                        <p class="scientific-name"><em>@s.ScientificName</em></p>
+                            <MudExpansionPanel Expanded="@(expandedSpeciesId == s.Id)"
+                                               ExpandedChanged="@((bool expanded) => ToggleSpecies(s.Id, expanded))"
+                                               Class="mb-2"
+                                               Style="border: 1px solid #e0e0e0;">
+                                <TitleContent>
+                                    <div>
+                                        <MudText Typo="Typo.subtitle2" Color="Color.Primary">@s.CommonName</MudText>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                            <em>@s.ScientificName</em>
+                                        </MudText>
                                     </div>
-                                    <span class="expand-icon">@(expandedSpeciesId == s.Id ? "-" : "+")</span>
-                                </div>
-
-                                @if (expandedSpeciesId == s.Id && s.FwsLinks.Any())
-                                {
-                                    <div class="species-details">
-                                        <h4>Conservation Links</h4>
+                                </TitleContent>
+                                <ChildContent>
+                                    @if (s.FwsLinks.Any())
+                                    {
+                                        <MudText Typo="Typo.overline" Color="Color.Primary" Class="mb-2">Conservation Links</MudText>
                                         @foreach (var link in s.FwsLinks)
                                         {
-                                            <div class="fws-link">
-                                                <div class="practice">
-                                                    <span class="badge practice-badge">NRCS @link.NrcsPractice.Code</span>
-                                                    <span>@link.NrcsPractice.Name</span>
+                                            <MudPaper Elevation="0" Class="pa-2 mb-2" Style="background-color: #f5f5f5;">
+                                                <div class="d-flex align-start gap-2 mb-1">
+                                                    <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Filled">
+                                                        NRCS @link.NrcsPractice.Code
+                                                    </MudChip>
+                                                    <MudText Typo="Typo.body2">@link.NrcsPractice.Name</MudText>
                                                 </div>
-                                                <div class="action">
-                                                    <span class="badge action-badge">FWS @link.FwsAction.Code</span>
-                                                    <span>@link.FwsAction.Name</span>
+                                                <div class="d-flex align-start gap-2 mb-1">
+                                                    <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Filled">
+                                                        FWS @link.FwsAction.Code
+                                                    </MudChip>
+                                                    <MudText Typo="Typo.body2">@link.FwsAction.Name</MudText>
                                                 </div>
                                                 @if (!string.IsNullOrEmpty(link.Justification))
                                                 {
-                                                    <div class="justification">@link.Justification</div>
+                                                    <MudDivider Class="my-2" />
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                                        @link.Justification
+                                                    </MudText>
                                                 }
-                                            </div>
+                                            </MudPaper>
                                         }
-                                    </div>
-                                }
-                            </div>
+                                    }
+                                </ChildContent>
+                            </MudExpansionPanel>
                         }
-                    </div>
+                    </MudExpansionPanels>
                 }
-            </div>
+            </MudContainer>
         }
         else if (showAllSpecies)
         {
-            <div class="sidebar-header">
-                <h2>All Species</h2>
-                <button class="close-btn" @onclick="CloseAllSpecies">×</button>
-            </div>
+            <MudPaper Class="pa-3 mud-theme-primary" Square="true" Elevation="0">
+                <div class="d-flex justify-space-between align-center">
+                    <MudText Typo="Typo.subtitle1">All Species</MudText>
+                    <MudIconButton Icon="@Icons.Material.Filled.Close" Color="Color.Inherit" Size="Size.Small" OnClick="CloseAllSpecies" />
+                </div>
+            </MudPaper>
 
-            <div class="sidebar-content">
-                <p class="species-count">@allSpecies.Count species in database</p>
-                <div class="species-list">
+            <MudContainer Class="pa-3" MaxWidth="MaxWidth.False">
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
+                    @allSpecies.Count species in database
+                </MudText>
+
+                <MudList T="SpeciesForSearchDto" Dense="true">
                     @foreach (var s in allSpecies)
                     {
-                        <div class="species-card">
-                            <div class="species-header">
-                                <div class="species-info">
-                                    <h3 class="species-name">@s.CommonName</h3>
-                                    <p class="scientific-name"><em>@s.ScientificName</em></p>
-                                </div>
-                            </div>
-                        </div>
+                        <MudListItem>
+                            <MudText Typo="Typo.subtitle2" Color="Color.Primary">@s.CommonName</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                <em>@s.ScientificName</em>
+                            </MudText>
+                        </MudListItem>
                     }
-                </div>
-            </div>
+                </MudList>
+            </MudContainer>
         }
         else
         {
-            <div class="sidebar-header">
-                <h2>FaunaFinder</h2>
-            </div>
-            <div class="sidebar-content">
-                <p class="instructions">Click on a municipality on the map to view species and conservation information.</p>
-                <button class="view-all-btn" @onclick="() => LoadAllSpeciesCommand.ExecuteAsync(CancellationToken.None)">View All Species</button>
-            </div>
+            <MudPaper Class="pa-3 mud-theme-primary" Square="true" Elevation="0">
+                <MudText Typo="Typo.subtitle1">FaunaFinder</MudText>
+            </MudPaper>
+
+            <MudContainer Class="pa-4" MaxWidth="MaxWidth.False">
+                <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
+                    Click on a municipality on the map to view species and conservation information.
+                </MudText>
+                <MudButton Variant="Variant.Filled"
+                           Color="Color.Primary"
+                           FullWidth="true"
+                           OnClick="@(() => LoadAllSpeciesCommand.ExecuteAsync(CancellationToken.None))">
+                    View All Species
+                </MudButton>
+            </MudContainer>
         }
-    </aside>
+    </MudDrawer>
 </div>
 
 @code {
@@ -120,6 +150,11 @@
     private bool showAllSpecies = false;
     private int? expandedSpeciesId;
     private string? pendingGeoJsonId;
+
+    private void ToggleSpecies(int speciesId, bool expanded)
+    {
+        expandedSpeciesId = expanded ? speciesId : null;
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -170,10 +205,5 @@
     {
         showAllSpecies = false;
         allSpecies = [];
-    }
-
-    private void ToggleSpecies(int speciesId)
-    {
-        expandedSpeciesId = expandedSpeciesId == speciesId ? null : speciesId;
     }
 }

--- a/src/FaunaFinder.Api/Components/_Imports.razor
+++ b/src/FaunaFinder.Api/Components/_Imports.razor
@@ -14,3 +14,4 @@
 @using FaunaFinder.DataAccess.Interfaces
 @using Microsoft.Extensions.Logging
 @using BlazingSingularity
+@using MudBlazor

--- a/src/FaunaFinder.Api/FaunaFinder.Api.csproj
+++ b/src/FaunaFinder.Api/FaunaFinder.Api.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="MudBlazor" Version="8.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FaunaFinder.Api/Program.cs
+++ b/src/FaunaFinder.Api/Program.cs
@@ -1,8 +1,7 @@
 using FaunaFinder.Api.Components;
-using FaunaFinder.Database;
 using FaunaFinder.Database.Extensions;
 using FaunaFinder.DataAccess.Extensions;
-using Microsoft.EntityFrameworkCore;
+using MudBlazor.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -12,6 +11,9 @@ builder.AddServiceDefaults();
 // Add Blazor Server
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+
+// Add MudBlazor
+builder.Services.AddMudServices();
 
 // Add FaunaFinder Database (with snake_case naming and NoTracking)
 builder.AddFaunaFinderDatabase();

--- a/src/FaunaFinder.Api/wwwroot/css/app.css
+++ b/src/FaunaFinder.Api/wwwroot/css/app.css
@@ -1,125 +1,30 @@
-*, *::before, *::after { box-sizing: border-box; }
-
-:root {
-    --primary: #2d6a4f;
-    --primary-light: #40916c;
-    --primary-dark: #1b4332;
-    --bg: #f8f9fa;
-    --card-bg: #fff;
-    --text: #212529;
-    --text-muted: #6c757d;
-    --border: #dee2e6;
-}
-
-html, body { margin: 0; padding: 0; font-family: system-ui, sans-serif; background: var(--bg); color: var(--text); height: 100%; }
-
-.layout { display: flex; flex-direction: column; min-height: 100vh; }
-
-.header { background: var(--primary); color: #fff; padding: 0 1rem; }
-.header-content { max-width: 1400px; margin: 0 auto; display: flex; justify-content: space-between; align-items: center; height: 56px; }
-.logo { text-decoration: none; color: #fff; font-size: 1.4rem; font-weight: 700; }
-.nav { display: flex; gap: 1rem; }
-.nav-link { color: rgba(255,255,255,0.9); text-decoration: none; padding: 0.5rem 1rem; border-radius: 4px; }
-.nav-link:hover { background: rgba(255,255,255,0.1); }
-
-.main-content { flex: 1; display: flex; }
-.footer { background: var(--primary-dark); color: rgba(255,255,255,0.8); text-align: center; padding: 0.75rem; font-size: 0.875rem; }
-
-.map-page { display: flex; flex: 1; position: relative; height: calc(100vh - 56px - 45px); }
-.map-container { flex: 1; position: relative; }
-.map { position: absolute; inset: 0; z-index: 1; }
-
-.sidebar {
-    width: 350px;
-    min-width: 350px;
-    background: var(--card-bg);
-    box-shadow: -2px 0 8px rgba(0,0,0,0.1);
-    z-index: 100;
+/* Map-specific styles - required for Leaflet integration */
+.map-page {
     display: flex;
-    flex-direction: column;
-    height: 100%;
-    overflow: hidden;
-}
-
-.sidebar-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem;
-    background: var(--primary);
-    color: #fff;
-    flex-shrink: 0;
-}
-.sidebar-header h2 { margin: 0; font-size: 1.1rem; }
-.close-btn {
-    background: rgba(255,255,255,0.2);
-    border: none;
-    color: #fff;
-    font-size: 0.9rem;
-    cursor: pointer;
-    padding: 0.4rem 0.8rem;
-    border-radius: 4px;
-}
-.close-btn:hover { background: rgba(255,255,255,0.3); }
-
-.sidebar-content {
     flex: 1;
+    position: relative;
+    height: calc(100vh - 48px);
+}
+
+.map-container {
+    flex: 1;
+    position: relative;
+}
+
+.map {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+}
+
+.sidebar-drawer {
+    height: calc(100vh - 48px) !important;
+    top: 48px !important;
     overflow-y: auto;
-    padding: 1rem;
 }
 
-.instructions {
-    color: var(--text-muted);
-    line-height: 1.6;
-    margin-bottom: 1.5rem;
-}
-
-.view-all-btn {
-    width: 100%;
-    padding: 0.75rem 1rem;
-    background: var(--primary);
-    color: #fff;
-    border: none;
-    border-radius: 6px;
-    font-size: 1rem;
-    cursor: pointer;
-    font-weight: 500;
-}
-.view-all-btn:hover { background: var(--primary-dark); }
-
-.species-count { color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1rem; }
-.species-list { display: flex; flex-direction: column; gap: 0.5rem; }
-
-.species-card { background: var(--card-bg); border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
-.species-header { display: flex; justify-content: space-between; align-items: center; padding: 0.75rem; cursor: pointer; background: #fafafa; }
-.species-header:hover { background: #f0f0f0; }
-.species-info { flex: 1; }
-.species-name { margin: 0; font-size: 0.95rem; font-weight: 600; color: var(--primary-dark); }
-.scientific-name { margin: 0.2rem 0 0; font-size: 0.8rem; color: var(--text-muted); }
-.expand-icon { color: var(--text-muted); font-weight: 300; font-size: 1.2rem; }
-
-.species-details { padding: 0.75rem; border-top: 1px solid var(--border); background: #fff; }
-.species-details h4 { margin: 0 0 0.5rem; font-size: 0.8rem; color: var(--primary); text-transform: uppercase; }
-
-.fws-link { padding: 0.5rem; background: #f8f9fa; border-radius: 4px; margin-bottom: 0.5rem; font-size: 0.85rem; }
-.practice, .action { display: flex; align-items: flex-start; gap: 0.4rem; margin-bottom: 0.3rem; }
-.badge { padding: 0.2rem 0.4rem; font-size: 0.7rem; font-weight: 600; border-radius: 3px; white-space: nowrap; }
-.practice-badge { background: var(--primary); color: #fff; }
-.action-badge { background: var(--primary-light); color: #fff; }
-.justification { font-size: 0.8rem; color: var(--text-muted); margin-top: 0.4rem; padding-top: 0.4rem; border-top: 1px dashed var(--border); }
-
-.loading { display: flex; flex-direction: column; align-items: center; padding: 2rem; color: var(--text-muted); }
-.spinner { width: 32px; height: 32px; border: 3px solid var(--border); border-top-color: var(--primary); border-radius: 50%; animation: spin 1s linear infinite; }
-@keyframes spin { to { transform: rotate(360deg); } }
-
-.no-data { color: var(--text-muted); text-align: center; padding: 2rem; }
-
-.about-page { max-width: 700px; margin: 0 auto; padding: 2rem; }
-.about-page h1 { color: var(--primary-dark); }
-.about-section { margin-bottom: 1.5rem; }
-.about-section h2 { color: var(--primary); font-size: 1.1rem; }
-.about-section ul { padding-left: 1.5rem; line-height: 1.8; }
-
-@media (max-width: 768px) {
-    .sidebar { width: 100%; min-width: 100%; position: absolute; right: 0; top: 0; bottom: 0; }
+@media (max-width: 960px) {
+    .sidebar-drawer {
+        width: 100% !important;
+    }
 }


### PR DESCRIPTION
Closes #13

## Summary

- Replace all custom CSS styling with MudBlazor component library
- Configure custom theme with green color palette matching original design
- Remove all inline CSS styles
- Only minimal CSS remains for Leaflet map integration

## Changes

### Added
- MudBlazor v8.4.0 package
- MudThemeProvider with custom palette
- MudBlazor service registration

### Replaced Components
| Before | After |
|--------|-------|
| Custom header/nav | `MudAppBar`, `MudButton` |
| Custom sidebar | `MudDrawer` |
| Custom species cards | `MudExpansionPanels` |
| Custom loading spinner | `MudProgressCircular` |
| Custom badges | `MudChip` |
| Custom buttons | `MudButton` |
| Custom text styles | `MudText` with Typo variants |
| Custom lists | `MudList`, `MudListItem` |

### Removed
- 100+ lines of custom CSS (kept only ~30 lines for map container)
- All inline styles in components

## CSS Reduction

**Before:** 126 lines of custom CSS  
**After:** 30 lines (map-only styles)

## Test plan

- [ ] Build succeeds with no errors
- [ ] App loads with MudBlazor styling
- [ ] Map displays correctly
- [ ] Sidebar drawer functions properly
- [ ] Species expansion panels work
- [ ] Navigation between pages works
- [ ] About page displays correctly

