### PR TITLE
Feature: Pueblos page with municipality cards and search

### DIFF
--- a/src/FaunaFinder.Api/Components/Layout/MainLayout.razor
+++ b/src/FaunaFinder.Api/Components/Layout/MainLayout.razor
@@ -10,6 +10,7 @@
         <MudText Typo="Typo.h6" Class="ml-2">FaunaFinder</MudText>
         <MudSpacer />
         <MudButton Href="/" Color="Color.Inherit" Variant="Variant.Text">Map</MudButton>
+        <MudButton Href="/pueblos" Color="Color.Inherit" Variant="Variant.Text">Pueblos</MudButton>
         <MudButton Href="/about" Color="Color.Inherit" Variant="Variant.Text">About</MudButton>
     </MudAppBar>
 

--- a/src/FaunaFinder.Api/Components/Pages/Pueblos.razor
+++ b/src/FaunaFinder.Api/Components/Pages/Pueblos.razor
@@ -1,0 +1,131 @@
+@page "/pueblos"
+@using FaunaFinder.Contracts.Dtos.Municipalities
+@using FaunaFinder.Contracts.Parameters
+@inject IMunicipalityRepository MunicipalityRepository
+
+<PageTitle>Pueblos - FaunaFinder</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-6">
+    <MudText Typo="Typo.h4" Color="Color.Primary" GutterBottom="true">Pueblos de Puerto Rico</MudText>
+    <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
+        Explore the municipalities of Puerto Rico and discover their biodiversity.
+    </MudText>
+
+    <MudTextField @bind-Value="searchTerm"
+                  Placeholder="Search municipalities..."
+                  Adornment="Adornment.Start"
+                  AdornmentIcon="@Icons.Material.Filled.Search"
+                  Variant="Variant.Outlined"
+                  Immediate="true"
+                  DebounceInterval="300"
+                  OnDebounceIntervalElapsed="OnSearchChanged"
+                  Class="mb-4" />
+
+    @if (isLoading)
+    {
+        <MudContainer Class="d-flex justify-center py-8">
+            <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+        </MudContainer>
+    }
+    else if (municipalities.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Text" Class="mb-4">
+            No municipalities found matching your search.
+        </MudAlert>
+    }
+    else
+    {
+        <MudGrid Spacing="3">
+            @foreach (var municipality in municipalities)
+            {
+                <MudItem xs="12" sm="6" md="4" lg="3">
+                    <MudCard Elevation="2" Class="municipality-card">
+                        <MudCardContent>
+                            <MudText Typo="Typo.h6" Color="Color.Primary">@municipality.Name</MudText>
+                            <div class="d-flex align-center mt-2">
+                                <MudIcon Icon="@Icons.Material.Filled.Pets" Size="Size.Small" Color="Color.Secondary" Class="mr-2" />
+                                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                                    @municipality.SpeciesCount @(municipality.SpeciesCount == 1 ? "species" : "species")
+                                </MudText>
+                            </div>
+                        </MudCardContent>
+                    </MudCard>
+                </MudItem>
+            }
+        </MudGrid>
+
+        <div class="d-flex justify-center mt-6">
+            <MudPagination Count="@totalPages"
+                          Selected="@(currentPage + 1)"
+                          SelectedChanged="OnPageChanged"
+                          Color="Color.Primary"
+                          Variant="Variant.Filled"
+                          ShowFirstButton="true"
+                          ShowLastButton="true" />
+        </div>
+
+        <MudText Typo="Typo.caption" Color="Color.Secondary" Align="Align.Center" Class="mt-2">
+            Showing @((currentPage * pageSize) + 1)-@Math.Min((currentPage + 1) * pageSize, totalCount) of @totalCount municipalities
+        </MudText>
+    }
+</MudContainer>
+
+<style>
+    .municipality-card {
+        transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+        height: 100%;
+    }
+
+    .municipality-card:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15) !important;
+    }
+</style>
+
+@code {
+    private IReadOnlyList<MunicipalityCardDto> municipalities = [];
+    private string searchTerm = string.Empty;
+    private int currentPage = 0;
+    private int pageSize = 12;
+    private int totalCount = 0;
+    private int totalPages = 0;
+    private bool isLoading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadMunicipalities();
+    }
+
+    private async Task LoadMunicipalities()
+    {
+        isLoading = true;
+        StateHasChanged();
+
+        var parameters = new MunicipalityParameters(
+            PageSize: pageSize,
+            Page: currentPage,
+            Search: string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm
+        );
+
+        municipalities = await MunicipalityRepository.GetMunicipalitiesWithSpeciesCountAsync(parameters);
+        totalCount = await MunicipalityRepository.GetTotalMunicipalitiesCountAsync(
+            string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm
+        );
+        totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
+
+        isLoading = false;
+        StateHasChanged();
+    }
+
+    private async Task OnSearchChanged()
+    {
+        currentPage = 0;
+        await LoadMunicipalities();
+    }
+
+    private async Task OnPageChanged(int page)
+    {
+        currentPage = page - 1;
+        await LoadMunicipalities();
+    }
+}

--- a/src/FaunaFinder.Contracts/Dtos/Municipalities/MunicipalityCardDto.cs
+++ b/src/FaunaFinder.Contracts/Dtos/Municipalities/MunicipalityCardDto.cs
@@ -1,0 +1,7 @@
+namespace FaunaFinder.Contracts.Dtos.Municipalities;
+
+public sealed record MunicipalityCardDto(
+    int Id,
+    string Name,
+    int SpeciesCount
+);

--- a/src/FaunaFinder.Contracts/Parameters/MunicipalityParameters.cs
+++ b/src/FaunaFinder.Contracts/Parameters/MunicipalityParameters.cs
@@ -1,0 +1,7 @@
+namespace FaunaFinder.Contracts.Parameters;
+
+public sealed record MunicipalityParameters(
+    int PageSize = 12,
+    int Page = 0,
+    string? Search = null
+);

--- a/src/FaunaFinder.DataAccess/Interfaces/IMunicipalityRepository.cs
+++ b/src/FaunaFinder.DataAccess/Interfaces/IMunicipalityRepository.cs
@@ -1,4 +1,5 @@
 using FaunaFinder.Contracts.Dtos.Municipalities;
+using FaunaFinder.Contracts.Parameters;
 
 namespace FaunaFinder.DataAccess.Interfaces;
 
@@ -9,5 +10,13 @@ public interface IMunicipalityRepository
 
     Task<MunicipalityForDetailDto?> GetMunicipalityDetailAsync(
         int municipalityId,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<MunicipalityCardDto>> GetMunicipalitiesWithSpeciesCountAsync(
+        MunicipalityParameters parameters,
+        CancellationToken cancellationToken = default);
+
+    Task<int> GetTotalMunicipalitiesCountAsync(
+        string? search = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/FaunaFinder.DataAccess/Repositories/MunicipalityRepository.cs
+++ b/src/FaunaFinder.DataAccess/Repositories/MunicipalityRepository.cs
@@ -1,4 +1,5 @@
 using FaunaFinder.Contracts.Dtos.Municipalities;
+using FaunaFinder.Contracts.Parameters;
 using FaunaFinder.Database;
 using FaunaFinder.DataAccess.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -41,5 +42,48 @@ public sealed class MunicipalityRepository(
                 m.MunicipalitySpecies.Count
             ))
             .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<MunicipalityCardDto>> GetMunicipalitiesWithSpeciesCountAsync(
+        MunicipalityParameters parameters,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var query = context.Municipalities.AsNoTracking().AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(parameters.Search))
+        {
+            var search = parameters.Search.ToLower();
+            query = query.Where(m => m.Name.ToLower().Contains(search));
+        }
+
+        return await query
+            .OrderBy(static m => m.Name)
+            .Skip(parameters.Page * parameters.PageSize)
+            .Take(parameters.PageSize)
+            .Select(static m => new MunicipalityCardDto(
+                m.Id,
+                m.Name,
+                m.MunicipalitySpecies.Count
+            ))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<int> GetTotalMunicipalitiesCountAsync(
+        string? search = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var query = context.Municipalities.AsNoTracking().AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var searchLower = search.ToLower();
+            query = query.Where(m => m.Name.ToLower().Contains(searchLower));
+        }
+
+        return await query.CountAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- Implements the Pueblos page to display Puerto Rico municipalities as cards
- Server-side pagination with configurable page size (12 per page)
- Database-driven search functionality to filter municipalities by name
- Shows species count for each municipality

Closes #16

## Changes

### New Files
- `src/FaunaFinder.Contracts/Dtos/Municipalities/MunicipalityCardDto.cs` - Card data DTO
- `src/FaunaFinder.Contracts/Parameters/MunicipalityParameters.cs` - Pagination/search params
- `src/FaunaFinder.Api/Components/Pages/Pueblos.razor` - Page component

### Modified Files
- `src/FaunaFinder.DataAccess/Interfaces/IMunicipalityRepository.cs` - Added pagination methods
- `src/FaunaFinder.DataAccess/Repositories/MunicipalityRepository.cs` - Implemented methods
- `src/FaunaFinder.Api/Components/Layout/MainLayout.razor` - Added nav link

## Test plan
- [ ] Navigate to /pueblos and verify municipalities load
- [ ] Verify pagination works (navigate between pages)
- [ ] Verify search filters municipalities correctly
- [ ] Verify species count displays for each municipality
- [ ] Test on mobile viewport for responsiveness