### PR TITLE
Update municipality GeoJsonId to full FIPS code format

### DIFF
--- a/src/FaunaFinder.Api/Components/Pages/Home.razor
+++ b/src/FaunaFinder.Api/Components/Pages/Home.razor
@@ -7,6 +7,7 @@
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
 @inject IAppLocalizer L
+@inject ISnackbar Snackbar
 
 <PageTitle>@L["PageTitle_Home"]</PageTitle>
 
@@ -1023,10 +1024,13 @@
     [JSInvokable]
     public async Task OnMunicipalityClick(string geoJsonId, string name)
     {
-        // Try full geoJsonId first, then try county-only (strip "72" state prefix for Puerto Rico)
-        var countyOnly = geoJsonId.StartsWith("72") ? geoJsonId[2..] : geoJsonId;
-        var municipality = municipalities?.FirstOrDefault(m => m.GeoJsonId == geoJsonId)
-            ?? municipalities?.FirstOrDefault(m => m.GeoJsonId == countyOnly);
+        var municipality = municipalities?.FirstOrDefault(m => m.GeoJsonId == geoJsonId);
+
+        if (municipality is null)
+        {
+            Snackbar.Add(L["MunicipalityNotFound", name], Severity.Warning);
+            return;
+        }
 
         showAllSpecies = false;
         showNearbySpecies = false;

--- a/src/FaunaFinder.Api/Services/Localization/Translations.cs
+++ b/src/FaunaFinder.Api/Services/Localization/Translations.cs
@@ -26,6 +26,7 @@ public static class Translations
         ["Error_UnexpectedError"] = "An unexpected error occurred. Please try again.",
         ["Error_SpeciesNotFound"] = "Species not found.",
         ["Error_MunicipalityNotFound"] = "Municipality not found.",
+        ["MunicipalityNotFound"] = "Municipality '{0}' not found in database.",
 
         // Home Page
         ["Home_ClickMunicipality"] = "Click on a municipality on the map to view species and conservation information.",
@@ -143,6 +144,7 @@ public static class Translations
         ["Error_UnexpectedError"] = "Ocurrió un error inesperado. Por favor, inténtelo de nuevo.",
         ["Error_SpeciesNotFound"] = "Especie no encontrada.",
         ["Error_MunicipalityNotFound"] = "Municipio no encontrado.",
+        ["MunicipalityNotFound"] = "Municipio '{0}' no encontrado en la base de datos.",
 
         // Home Page
         ["Home_ClickMunicipality"] = "Haz clic en un municipio en el mapa para ver información sobre especies y conservación.",

--- a/src/FaunaFinder.Seeder/DatabaseSeeder.cs
+++ b/src/FaunaFinder.Seeder/DatabaseSeeder.cs
@@ -15,39 +15,40 @@ public static class DatabaseSeeder
 
         // === MUNICIPALITIES ===
         // Grouped by region for species distribution
+        // GeoJsonId uses full FIPS code format: STATE (72 = Puerto Rico) + COUNTY
         var municipalities = new List<Municipality>
         {
             // Northeast (San Juan Metro)
-            new() { Id = 0, Name = "San Juan", GeoJsonId = "127" },
-            new() { Id = 0, Name = "Bayamon", GeoJsonId = "021" },
-            new() { Id = 0, Name = "Carolina", GeoJsonId = "031" },
-            new() { Id = 0, Name = "Guaynabo", GeoJsonId = "061" },
+            new() { Id = 0, Name = "San Juan", GeoJsonId = "72127" },
+            new() { Id = 0, Name = "Bayamon", GeoJsonId = "72021" },
+            new() { Id = 0, Name = "Carolina", GeoJsonId = "72031" },
+            new() { Id = 0, Name = "Guaynabo", GeoJsonId = "72061" },
 
             // East
-            new() { Id = 0, Name = "Fajardo", GeoJsonId = "053" },
-            new() { Id = 0, Name = "Humacao", GeoJsonId = "069" },
-            new() { Id = 0, Name = "Caguas", GeoJsonId = "025" },
+            new() { Id = 0, Name = "Fajardo", GeoJsonId = "72053" },
+            new() { Id = 0, Name = "Humacao", GeoJsonId = "72069" },
+            new() { Id = 0, Name = "Caguas", GeoJsonId = "72025" },
 
             // South
-            new() { Id = 0, Name = "Ponce", GeoJsonId = "113" },
-            new() { Id = 0, Name = "Guayama", GeoJsonId = "057" },
-            new() { Id = 0, Name = "Yauco", GeoJsonId = "153" },
+            new() { Id = 0, Name = "Ponce", GeoJsonId = "72113" },
+            new() { Id = 0, Name = "Guayama", GeoJsonId = "72057" },
+            new() { Id = 0, Name = "Yauco", GeoJsonId = "72153" },
 
             // West
-            new() { Id = 0, Name = "Mayaguez", GeoJsonId = "097" },
-            new() { Id = 0, Name = "Cabo Rojo", GeoJsonId = "023" },
-            new() { Id = 0, Name = "Rincon", GeoJsonId = "117" },
-            new() { Id = 0, Name = "Aguadilla", GeoJsonId = "003" },
+            new() { Id = 0, Name = "Mayaguez", GeoJsonId = "72097" },
+            new() { Id = 0, Name = "Cabo Rojo", GeoJsonId = "72023" },
+            new() { Id = 0, Name = "Rincon", GeoJsonId = "72117" },
+            new() { Id = 0, Name = "Aguadilla", GeoJsonId = "72003" },
 
             // North
-            new() { Id = 0, Name = "Arecibo", GeoJsonId = "013" },
-            new() { Id = 0, Name = "Vega Baja", GeoJsonId = "145" },
-            new() { Id = 0, Name = "Manati", GeoJsonId = "091" },
-            new() { Id = 0, Name = "Isabela", GeoJsonId = "071" },
+            new() { Id = 0, Name = "Arecibo", GeoJsonId = "72013" },
+            new() { Id = 0, Name = "Vega Baja", GeoJsonId = "72145" },
+            new() { Id = 0, Name = "Manati", GeoJsonId = "72091" },
+            new() { Id = 0, Name = "Isabela", GeoJsonId = "72071" },
 
             // Islands
-            new() { Id = 0, Name = "Vieques", GeoJsonId = "147" },
-            new() { Id = 0, Name = "Culebra", GeoJsonId = "049" },
+            new() { Id = 0, Name = "Vieques", GeoJsonId = "72147" },
+            new() { Id = 0, Name = "Culebra", GeoJsonId = "72049" },
         };
         context.Municipalities.AddRange(municipalities);
         await context.SaveChangesAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- Updates seed data to use full FIPS codes (STATE 72 + COUNTY) instead of county-only codes
- Removes workaround code in `OnMunicipalityClick` that previously stripped the "72" prefix
- Adds snackbar notification when municipality lookup fails (defensive measure)

## Test plan
- [ ] Delete existing database and run seeder to recreate with new FIPS codes
- [ ] Click on municipalities on the map and verify species load correctly
- [ ] Verify no console errors about municipality not found

Closes #47