### PR TITLE
Create reusable species display components

### DIFF
--- a/src/FaunaFinder.Api/Components/Pages/Map.razor
+++ b/src/FaunaFinder.Api/Components/Pages/Map.razor
@@ -153,15 +153,13 @@
                         @string.Format(L["Map_SpeciesInDatabase"], allSpecies.Count)
                     </MudText>
 
-                    <MudList T="SpeciesForSearchDto" Dense="true">
+                    <MudList T="string" Dense="true">
                         @foreach (var s in allSpecies)
                         {
-                            <MudListItem>
-                                <MudText Typo="Typo.subtitle2" Color="Color.Primary">@L.GetLocalizedValue(s.CommonName)</MudText>
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                    <em>@s.ScientificName</em>
-                                </MudText>
-                            </MudListItem>
+                            <SpeciesListItem CommonName="s.CommonName"
+                                             ScientificName="s.ScientificName"
+                                             ShowDetailsButton="true"
+                                             OnDetailsClick="@(() => NavigateToSpeciesDetail(s.Id))" />
                         }
                     </MudList>
                 </div>
@@ -406,15 +404,13 @@
                             @string.Format(L["Map_SpeciesInDatabase"], allSpecies.Count)
                         </MudText>
 
-                        <MudList T="SpeciesForSearchDto" Dense="true">
+                        <MudList T="string" Dense="true">
                             @foreach (var s in allSpecies)
                             {
-                                <MudListItem>
-                                    <MudText Typo="Typo.subtitle2" Color="Color.Primary">@L.GetLocalizedValue(s.CommonName)</MudText>
-                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                        <em>@s.ScientificName</em>
-                                    </MudText>
-                                </MudListItem>
+                                <SpeciesListItem CommonName="s.CommonName"
+                                                 ScientificName="s.ScientificName"
+                                                 ShowDetailsButton="true"
+                                                 OnDetailsClick="@(() => NavigateToSpeciesDetail(s.Id))" />
                             }
                         </MudList>
                     </MudContainer>

--- a/src/FaunaFinder.Api/Components/Pages/MapComponents/SpeciesExpansionPanel.razor
+++ b/src/FaunaFinder.Api/Components/Pages/MapComponents/SpeciesExpansionPanel.razor
@@ -2,44 +2,35 @@
 
 <MudExpansionPanel Expanded="@IsExpanded"
                    ExpandedChanged="@OnExpandedChanged"
-                   Class="mb-2 border-default">
+                   Class="mb-2">
     <TitleContent>
-        <div>
-            <MudText Typo="Typo.subtitle2" Color="Color.Primary">@L.GetLocalizedValue(Species.CommonName)</MudText>
-            <MudText Typo="Typo.caption" Color="Color.Secondary">
-                <em>@Species.ScientificName</em>
-            </MudText>
+        <div class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between" style="width: 100%;">
+            <div class="d-flex flex-column flex-sm-row align-start align-sm-center">
+                <MudText Typo="@TitleTypo" Color="Color.Primary" Class="@(ShowViewDetails ? "mr-4" : "")">
+                    @L.GetLocalizedValue(Species.CommonName)
+                </MudText>
+                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                    <em>@Species.ScientificName</em>
+                </MudText>
+            </div>
+            @if (ShowViewDetails && OnViewDetails.HasDelegate)
+            {
+                <div @onclick:stopPropagation="true">
+                    <MudButton Variant="Variant.Text"
+                               Color="Color.Primary"
+                               Size="Size.Small"
+                               EndIcon="@Icons.Material.Filled.OpenInNew"
+                               OnClick="OnViewDetails">
+                        @L["ViewDetails"]
+                    </MudButton>
+                </div>
+            }
         </div>
     </TitleContent>
     <ChildContent>
-        @if (Species.FwsLinks.Any())
-        {
-            <MudText Typo="Typo.overline" Color="Color.Primary" Class="mb-2">@L["Map_ConservationLinks"]</MudText>
-            @foreach (var link in Species.FwsLinks)
-            {
-                <MudPaper Elevation="0" Class="pa-2 mb-2 bg-subtle">
-                    <div class="d-flex align-start gap-2 mb-1">
-                        <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Filled">
-                            NRCS @link.NrcsPractice.Code
-                        </MudChip>
-                        <MudText Typo="Typo.body2">@link.NrcsPractice.Name</MudText>
-                    </div>
-                    <div class="d-flex align-start gap-2 mb-1">
-                        <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Filled">
-                            FWS @link.FwsAction.Code
-                        </MudChip>
-                        <MudText Typo="Typo.body2">@link.FwsAction.Name</MudText>
-                    </div>
-                    @if (!string.IsNullOrEmpty(link.Justification))
-                    {
-                        <MudDivider Class="my-2" />
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">
-                            @link.Justification
-                        </MudText>
-                    }
-                </MudPaper>
-            }
-        }
+        <ConservationLinksList Links="Species.FwsLinks"
+                               UseGrid="UseGridLayout"
+                               ShowEmptyMessage="ShowEmptyMessage" />
     </ChildContent>
 </MudExpansionPanel>
 
@@ -47,7 +38,27 @@
     [CascadingParameter(Name = "LanguageRefresh")]
     private int LanguageRefresh { get; set; }
 
-    [Parameter, EditorRequired] public SpeciesForListDto Species { get; set; } = null!;
-    [Parameter] public bool IsExpanded { get; set; }
-    [Parameter] public EventCallback<bool> OnExpandedChanged { get; set; }
+    [Parameter, EditorRequired]
+    public SpeciesForListDto Species { get; set; } = null!;
+
+    [Parameter]
+    public bool IsExpanded { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> OnExpandedChanged { get; set; }
+
+    [Parameter]
+    public bool ShowViewDetails { get; set; }
+
+    [Parameter]
+    public EventCallback OnViewDetails { get; set; }
+
+    [Parameter]
+    public bool UseGridLayout { get; set; }
+
+    [Parameter]
+    public bool ShowEmptyMessage { get; set; }
+
+    [Parameter]
+    public Typo TitleTypo { get; set; } = Typo.subtitle2;
 }

--- a/src/FaunaFinder.Api/Components/Pages/PuebloDetail.razor
+++ b/src/FaunaFinder.Api/Components/Pages/PuebloDetail.razor
@@ -56,69 +56,14 @@
             <MudExpansionPanels MultiExpansion="false" Elevation="1">
                 @foreach (var s in species)
                 {
-                    <MudExpansionPanel Expanded="@(expandedSpeciesId == s.Id)"
-                                       ExpandedChanged="@((bool expanded) => ToggleSpecies(s.Id, expanded))"
-                                       Class="mb-2 pa-2">
-                        <TitleContent>
-                            <div class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between" style="width: 100%;">
-                                <div class="d-flex flex-column flex-sm-row align-start align-sm-center">
-                                    <MudText Typo="Typo.subtitle1" Color="Color.Primary" Class="mr-4">@L.GetLocalizedValue(s.CommonName)</MudText>
-                                    <MudText Typo="Typo.body2" Color="Color.Secondary">
-                                        <em>@s.ScientificName</em>
-                                    </MudText>
-                                </div>
-                                <div @onclick:stopPropagation="true">
-                                    <MudButton Variant="Variant.Text"
-                                               Color="Color.Primary"
-                                               Size="Size.Small"
-                                               EndIcon="@Icons.Material.Filled.OpenInNew"
-                                               OnClick="@(() => NavigateToSpecies(s.Id))">
-                                        @L["ViewDetails"]
-                                    </MudButton>
-                                </div>
-                            </div>
-                        </TitleContent>
-                        <ChildContent>
-                            @if (s.FwsLinks.Any())
-                            {
-                                <MudText Typo="Typo.overline" Color="Color.Primary" Class="mb-3">@L["Map_ConservationLinks"]</MudText>
-                                <MudGrid Spacing="2">
-                                    @foreach (var link in s.FwsLinks)
-                                    {
-                                        <MudItem xs="12" md="6">
-                                            <MudPaper Elevation="0" Class="pa-3 bg-subtle">
-                                                <div class="d-flex flex-wrap align-start gap-2 mb-2">
-                                                    <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Filled">
-                                                        NRCS @link.NrcsPractice.Code
-                                                    </MudChip>
-                                                    <MudText Typo="Typo.body2">@link.NrcsPractice.Name</MudText>
-                                                </div>
-                                                <div class="d-flex flex-wrap align-start gap-2 mb-2">
-                                                    <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Filled">
-                                                        FWS @link.FwsAction.Code
-                                                    </MudChip>
-                                                    <MudText Typo="Typo.body2">@link.FwsAction.Name</MudText>
-                                                </div>
-                                                @if (!string.IsNullOrEmpty(link.Justification))
-                                                {
-                                                    <MudDivider Class="my-2" />
-                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                                        @link.Justification
-                                                    </MudText>
-                                                }
-                                            </MudPaper>
-                                        </MudItem>
-                                    }
-                                </MudGrid>
-                            }
-                            else
-                            {
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">
-                                    @L["PuebloDetail_NoConservationLinks"]
-                                </MudText>
-                            }
-                        </ChildContent>
-                    </MudExpansionPanel>
+                    <SpeciesExpansionPanel Species="s"
+                                           IsExpanded="@(expandedSpeciesId == s.Id)"
+                                           OnExpandedChanged="@((bool expanded) => ToggleSpecies(s.Id, expanded))"
+                                           ShowViewDetails="true"
+                                           OnViewDetails="@(() => NavigateToSpecies(s.Id))"
+                                           UseGridLayout="true"
+                                           ShowEmptyMessage="true"
+                                           TitleTypo="Typo.subtitle1" />
                 }
             </MudExpansionPanels>
         }

--- a/src/FaunaFinder.Api/Components/Shared/ConservationLinkCard.razor
+++ b/src/FaunaFinder.Api/Components/Shared/ConservationLinkCard.razor
@@ -1,0 +1,26 @@
+<MudPaper Elevation="0" Class="pa-2 mb-2 bg-subtle">
+    <div class="d-flex align-start gap-2 mb-1">
+        <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Filled">
+            NRCS @Link.NrcsPractice.Code
+        </MudChip>
+        <MudText Typo="Typo.body2">@Link.NrcsPractice.Name</MudText>
+    </div>
+    <div class="d-flex align-start gap-2 mb-1">
+        <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Filled">
+            FWS @Link.FwsAction.Code
+        </MudChip>
+        <MudText Typo="Typo.body2">@Link.FwsAction.Name</MudText>
+    </div>
+    @if (!string.IsNullOrEmpty(Link.Justification))
+    {
+        <MudDivider Class="my-2" />
+        <MudText Typo="Typo.caption" Color="Color.Secondary">
+            @Link.Justification
+        </MudText>
+    }
+</MudPaper>
+
+@code {
+    [Parameter, EditorRequired]
+    public FwsLinkDto Link { get; set; } = null!;
+}

--- a/src/FaunaFinder.Api/Components/Shared/ConservationLinksList.razor
+++ b/src/FaunaFinder.Api/Components/Shared/ConservationLinksList.razor
@@ -1,0 +1,48 @@
+@inject IAppLocalizer L
+
+@if (Links.Any())
+{
+    @if (ShowTitle)
+    {
+        <MudText Typo="Typo.overline" Color="Color.Primary" Class="mb-2">@L["Map_ConservationLinks"]</MudText>
+    }
+
+    @if (UseGrid)
+    {
+        <MudGrid Spacing="2">
+            @foreach (var link in Links)
+            {
+                <MudItem xs="12" md="6">
+                    <ConservationLinkCard Link="link" />
+                </MudItem>
+            }
+        </MudGrid>
+    }
+    else
+    {
+        @foreach (var link in Links)
+        {
+            <ConservationLinkCard Link="link" />
+        }
+    }
+}
+else if (ShowEmptyMessage)
+{
+    <MudText Typo="Typo.body2" Color="Color.Secondary">
+        @L["PuebloDetail_NoConservationLinks"]
+    </MudText>
+}
+
+@code {
+    [Parameter, EditorRequired]
+    public IEnumerable<FwsLinkDto> Links { get; set; } = [];
+
+    [Parameter]
+    public bool ShowTitle { get; set; } = true;
+
+    [Parameter]
+    public bool UseGrid { get; set; }
+
+    [Parameter]
+    public bool ShowEmptyMessage { get; set; }
+}

--- a/src/FaunaFinder.Api/Components/Shared/SpeciesListItem.razor
+++ b/src/FaunaFinder.Api/Components/Shared/SpeciesListItem.razor
@@ -1,0 +1,42 @@
+@inject IAppLocalizer L
+
+<MudListItem T="string" OnClick="OnClick">
+    <div class="d-flex justify-space-between align-center">
+        <div>
+            <MudText Typo="Typo.subtitle2" Color="Color.Primary">@L.GetLocalizedValue(CommonName)</MudText>
+            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                <em>@ScientificName</em>
+            </MudText>
+        </div>
+        @if (ShowDetailsButton && OnDetailsClick.HasDelegate)
+        {
+            <MudButton Variant="Variant.Text"
+                       Size="Size.Small"
+                       EndIcon="@Icons.Material.Filled.ChevronRight"
+                       OnClick="OnDetailsClick"
+                       Color="Color.Primary">
+                @L["Details"]
+            </MudButton>
+        }
+    </div>
+</MudListItem>
+
+@code {
+    [CascadingParameter(Name = "LanguageRefresh")]
+    private int LanguageRefresh { get; set; }
+
+    [Parameter, EditorRequired]
+    public List<LocaleValue> CommonName { get; set; } = [];
+
+    [Parameter, EditorRequired]
+    public string ScientificName { get; set; } = string.Empty;
+
+    [Parameter]
+    public EventCallback OnClick { get; set; }
+
+    [Parameter]
+    public bool ShowDetailsButton { get; set; }
+
+    [Parameter]
+    public EventCallback OnDetailsClick { get; set; }
+}

--- a/src/FaunaFinder.Api/Components/_Imports.razor
+++ b/src/FaunaFinder.Api/Components/_Imports.razor
@@ -11,6 +11,7 @@
 @using FaunaFinder.Api.Components.Shared
 @using FaunaFinder.Api.Services.DarkMode
 @using FaunaFinder.Api.Services.Localization
+@using FaunaFinder.Contracts.Localization
 @using FaunaFinder.Contracts.Dtos.Municipalities
 @using FaunaFinder.Contracts.Dtos.Species
 @using FaunaFinder.Contracts.Dtos.FwsLinks


### PR DESCRIPTION
## Summary
- Add `ConservationLinkCard` component for displaying a single FWS link
- Add `ConservationLinksList` component for displaying multiple FWS links with optional grid layout
- Add `SpeciesListItem` component for simple species list display with optional details button
- Enhance `SpeciesExpansionPanel` with optional View Details button, grid layout, and empty message support
- Refactor `PuebloDetail.razor` to use the reusable `SpeciesExpansionPanel`
- Refactor `Map.razor` "View All Species" to use the new `SpeciesListItem` component

## New Components
- `ConservationLinkCard.razor` - Displays NRCS practice, FWS action, and justification
- `ConservationLinksList.razor` - Displays a list of conservation links with optional title and grid layout
- `SpeciesListItem.razor` - Simple list item with common name, scientific name, and optional details button

## Test plan
- [ ] Verify species list displays correctly on Map page "View All Species"
- [ ] Verify species expansion panels work on Map page municipality selection
- [ ] Verify species expansion panels work on PuebloDetail page
- [ ] Verify "View Details" buttons navigate correctly
- [ ] Verify conservation links display properly in all contexts

Closes #63