### PR TITLE
Add skeleton loading states to Municipalities pages

### DIFF
--- a/src/FaunaFinder.Client/Pages/PuebloDetail.razor
+++ b/src/FaunaFinder.Client/Pages/PuebloDetail.razor
@@ -17,11 +17,13 @@
         @L["Back"]
     </MudButton>
 
-    @if (LoadDataCommand.IsLoading)
+    @* Municipality Header Section *@
+    @if (isLoadingMunicipality)
     {
-        <MudContainer Class="d-flex justify-center py-8">
-            <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
-        </MudContainer>
+        <MudPaper Elevation="2" Class="pa-4 mb-6">
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="40px" Width="50%" Class="mb-3 rounded" />
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="24px" Width="30%" Class="rounded" />
+        </MudPaper>
     }
     else if (municipality == null)
     {
@@ -31,7 +33,6 @@
     }
     else
     {
-        @* Municipality Header *@
         <MudPaper Elevation="2" Class="pa-4 mb-6">
             <MudText Typo="Typo.h4" Color="Color.Primary" GutterBottom="true">@municipality.Name</MudText>
             <div class="d-flex align-center">
@@ -41,11 +42,21 @@
                 </MudText>
             </div>
         </MudPaper>
+    }
 
-        @* Species List *@
+    @* Species List Section - only show if municipality loaded *@
+    @if (municipality != null || isLoadingMunicipality)
+    {
         <MudText Typo="Typo.h5" Color="Color.Primary" GutterBottom="true" Class="mb-4">@L["PuebloDetail_SpeciesInMunicipality"]</MudText>
 
-        @if (species.Count == 0)
+        @if (isLoadingSpecies)
+        {
+            @for (int i = 0; i < 6; i++)
+            {
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="60px" Class="mb-3 rounded" />
+            }
+        }
+        else if (species.Count == 0)
         {
             <MudAlert Severity="Severity.Info" Variant="Variant.Text" Class="mb-4">
                 @L["PuebloDetail_NoSpeciesData"]
@@ -81,20 +92,32 @@
     private IReadOnlyList<SpeciesForListDto> species = [];
     private int? expandedSpeciesId;
 
+    private bool isLoadingMunicipality = true;
+    private bool isLoadingSpecies = true;
+
     protected override async Task OnInitializedAsync()
     {
-        await LoadDataCommand.ExecuteAsync();
+        // Load both in parallel
+        var municipalityTask = LoadMunicipalityAsync();
+        var speciesTask = LoadSpeciesAsync();
+
+        await Task.WhenAll(municipalityTask, speciesTask);
     }
 
-    [RelayCommand]
-    private async Task LoadData()
+    private async Task LoadMunicipalityAsync()
     {
+        isLoadingMunicipality = true;
         municipality = await MunicipalityService.GetMunicipalityDetailAsync(Id);
+        isLoadingMunicipality = false;
+        StateHasChanged();
+    }
 
-        if (municipality != null)
-        {
-            species = await SpeciesService.GetSpeciesByMunicipalityAsync(Id);
-        }
+    private async Task LoadSpeciesAsync()
+    {
+        isLoadingSpecies = true;
+        species = await SpeciesService.GetSpeciesByMunicipalityAsync(Id);
+        isLoadingSpecies = false;
+        StateHasChanged();
     }
 
     private void ToggleSpecies(int speciesId, bool expanded)

--- a/src/FaunaFinder.Client/Pages/Pueblos.razor
+++ b/src/FaunaFinder.Client/Pages/Pueblos.razor
@@ -1,5 +1,4 @@
 @page "/pueblos"
-@using BlazingSingularity.Commands
 @inject IMunicipalityService MunicipalityService
 @inject NavigationManager NavigationManager
 @inject IAppLocalizer L
@@ -22,12 +21,17 @@
                   OnDebounceIntervalElapsed="OnSearchChanged"
                   Class="mb-4" />
 
-    @if (LoadMunicipalitiesCommand.IsLoading)
+    @* Municipalities Grid *@
+    @if (isLoadingMunicipalities)
     {
-        @for (int i = 0; i < 8; i++)
-        {
-            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="60px" Class="mb-3 rounded" />
-        }
+        <MudGrid Spacing="3">
+            @for (int i = 0; i < 8; i++)
+            {
+                <MudItem xs="12" sm="6" md="4" lg="3">
+                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="80px" Class="rounded" />
+                </MudItem>
+            }
+        </MudGrid>
     }
     else if (municipalities.Count == 0)
     {
@@ -55,20 +59,40 @@
                 </MudItem>
             }
         </MudGrid>
+    }
 
+    @* Pagination - show skeleton while count is loading *@
+    @if (municipalities.Count > 0 || isLoadingMunicipalities)
+    {
         <div class="d-flex justify-center mt-6">
-            <MudPagination Count="@totalPages"
-                          Selected="@(currentPage + 1)"
-                          SelectedChanged="OnPageChanged"
-                          Color="Color.Primary"
-                          Variant="Variant.Filled"
-                          ShowFirstButton="true"
-                          ShowLastButton="true" />
+            @if (isLoadingCount)
+            {
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="40px" Width="300px" Class="rounded" />
+            }
+            else
+            {
+                <MudPagination Count="@totalPages"
+                              Selected="@(currentPage + 1)"
+                              SelectedChanged="OnPageChanged"
+                              Color="Color.Primary"
+                              Variant="Variant.Filled"
+                              ShowFirstButton="true"
+                              ShowLastButton="true" />
+            }
         </div>
 
-        <MudText Typo="Typo.caption" Color="Color.Secondary" Align="Align.Center" Class="mt-2">
-            @L["Pueblos_Showing", (currentPage * pageSize) + 1, Math.Min((currentPage + 1) * pageSize, totalCount), totalCount]
-        </MudText>
+        <div class="d-flex justify-center mt-2">
+            @if (isLoadingCount)
+            {
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="20px" Width="200px" Class="rounded" />
+            }
+            else
+            {
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Align="Align.Center">
+                    @L["Pueblos_Showing", (currentPage * pageSize) + 1, Math.Min((currentPage + 1) * pageSize, totalCount), totalCount]
+                </MudText>
+            }
+        </div>
     }
 </MudContainer>
 
@@ -80,13 +104,26 @@
     private int totalCount = 0;
     private int totalPages = 0;
 
+    private bool isLoadingMunicipalities = true;
+    private bool isLoadingCount = true;
+
     protected override async Task OnInitializedAsync()
     {
-        await LoadMunicipalitiesCommand.ExecuteAsync();
+        await LoadDataAsync();
     }
 
-    [RelayCommand]
-    private async Task LoadMunicipalities()
+    private async Task LoadDataAsync()
+    {
+        isLoadingMunicipalities = true;
+        isLoadingCount = true;
+
+        var municipalitiesTask = LoadMunicipalitiesAsync();
+        var countTask = LoadCountAsync();
+
+        await Task.WhenAll(municipalitiesTask, countTask);
+    }
+
+    private async Task LoadMunicipalitiesAsync()
     {
         var parameters = new MunicipalityParameters(
             PageSize: pageSize,
@@ -95,22 +132,30 @@
         );
 
         municipalities = await MunicipalityService.GetMunicipalitiesWithSpeciesCountAsync(parameters);
+        isLoadingMunicipalities = false;
+        StateHasChanged();
+    }
+
+    private async Task LoadCountAsync()
+    {
         totalCount = await MunicipalityService.GetTotalMunicipalitiesCountAsync(
             string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm
         );
         totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
+        isLoadingCount = false;
+        StateHasChanged();
     }
 
     private async Task OnSearchChanged()
     {
         currentPage = 0;
-        await LoadMunicipalitiesCommand.ExecuteAsync();
+        await LoadDataAsync();
     }
 
     private async Task OnPageChanged(int page)
     {
         currentPage = page - 1;
-        await LoadMunicipalitiesCommand.ExecuteAsync();
+        await LoadDataAsync();
     }
 
     private void NavigateToDetail(int municipalityId)

--- a/src/FaunaFinder.Client/Properties/launchSettings.json
+++ b/src/FaunaFinder.Client/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "FaunaFinder.Client": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:52631;http://localhost:52632"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds skeleton loading placeholders to Pueblos.razor (listing)
- Adds skeleton loading placeholders to PuebloDetail.razor (detail)
- Uses MudSkeleton Rectangle type with MudBlazor utility classes
- Improves UX by showing loading state instead of blank/flash

Closes #70