### PR TITLE
Fix species name display in map popup

### DIFF
--- a/src/FaunaFinder.Client/Pages/Home.razor
+++ b/src/FaunaFinder.Client/Pages/Home.razor
@@ -671,7 +671,7 @@
                 description = l.Description
             }).ToArray();
 
-            await JS.InvokeVoidAsync("leafletInterop.showSpeciesLocations", viewingSpeciesLocations.CommonName, locations);
+            await JS.InvokeVoidAsync("leafletInterop.showSpeciesLocations", L.GetLocalizedValue(viewingSpeciesLocations.CommonName), locations);
 
             // Focus on the first location
             await JS.InvokeVoidAsync("leafletInterop.focusOnLocation", 0);


### PR DESCRIPTION
## Summary
- Fixed the [object Object] display bug in species map popup by localizing the CommonName property before passing it to JavaScript

## Test plan
- [ ] Navigate to a species detail and view its locations on the map
- [ ] Verify the popup displays the species name correctly instead of [object Object]
- [ ] Test with different language settings to confirm localization works

Fixes #77