### PR TITLE
Fix sidebar not appearing on user location

### DIFF
--- a/src/FaunaFinder.Client/Pages/Home.razor
+++ b/src/FaunaFinder.Client/Pages/Home.razor
@@ -755,11 +755,13 @@
     }
 
     [JSInvokable]
-    public void OnUserLocationFound(double latitude, double longitude)
+    public async Task OnUserLocationFound(double latitude, double longitude)
     {
         userLatitude = latitude;
         userLongitude = longitude;
-        StateHasChanged();
+
+        // When user locates themselves, show the sidebar with nearby species
+        await OpenSpeciesNearMe();
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
- Fixed issue where the sidebar did not appear when the user clicked the locate button to find their location on the map
- The `OnUserLocationFound` method now calls `OpenSpeciesNearMe()` to show the sidebar and fetch nearby species based on the user's location

## Test plan
- [ ] Click the locate button on the map
- [ ] Verify the browser prompts for location permission
- [ ] After granting permission, verify the sidebar appears showing nearby species
- [ ] Verify the search radius circle is displayed on the map
- [ ] Verify nearby species are listed with their distances

Fixes #82