### PR TITLE
Fix species locations not showing in Near Me mode

### DIFF
--- a/src/FaunaFinder.Api/Endpoints/SpeciesEndpoints.cs
+++ b/src/FaunaFinder.Api/Endpoints/SpeciesEndpoints.cs
@@ -67,5 +67,17 @@ public static class SpeciesEndpoints
             var page = await repository.GetSpeciesCursorPageAsync(request, ct);
             return Results.Ok(page);
         }).WithName("GetSpeciesCursor");
+
+        group.MapGet("/locations/batch", async (
+            string ids,
+            ISpeciesRepository repository,
+            CancellationToken ct) =>
+        {
+            var speciesIds = ids.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(int.Parse)
+                .ToList();
+            var locations = await repository.GetSpeciesLocationsBatchAsync(speciesIds, ct);
+            return Results.Ok(locations);
+        }).WithName("GetSpeciesLocationsBatch");
     }
 }

--- a/src/FaunaFinder.Client/Pages/Home.razor
+++ b/src/FaunaFinder.Client/Pages/Home.razor
@@ -909,18 +909,27 @@
             // Clear the default nearby species markers first to avoid overlap
             await JS.InvokeVoidAsync("leafletInterop.clearNearbySpeciesMarkers");
 
-            // Show species location circles on the map with distinct colors
-            var speciesLocations = nearbySpecies.Select(s => new
-            {
-                id = s.Id,
-                commonName = s.CommonName,
-                scientificName = s.ScientificName,
-                distanceMeters = s.DistanceMeters,
-                latitude = s.Latitude,
-                longitude = s.Longitude,
-                radiusMeters = s.RadiusMeters,
-                locationDescription = s.LocationDescription
-            }).ToArray();
+            // Get IDs of all nearby species and fetch ALL their locations
+            var speciesIds = nearbySpecies.Select(s => s.Id).Distinct().ToList();
+            var allSpeciesLocations = await SpeciesService.GetSpeciesLocationsBatchAsync(speciesIds);
+
+            // Build a lookup for distance from the nearest location (for display)
+            var nearestDistances = nearbySpecies.ToDictionary(s => s.Id, s => s.DistanceMeters);
+
+            // Flatten all locations from all species into a single array
+            var speciesLocations = allSpeciesLocations
+                .SelectMany(species => species.Locations.Select(loc => new
+                {
+                    id = species.Id,
+                    commonName = L.GetLocalizedValue(species.CommonName),
+                    scientificName = species.ScientificName,
+                    distanceMeters = nearestDistances.GetValueOrDefault(species.Id, 0),
+                    latitude = loc.Latitude,
+                    longitude = loc.Longitude,
+                    radiusMeters = loc.RadiusMeters,
+                    locationDescription = loc.Description
+                }))
+                .ToArray();
 
             await JS.InvokeVoidAsync("leafletInterop.showSpeciesLocationCircles", speciesLocations);
 

--- a/src/FaunaFinder.Client/Services/Api/ISpeciesService.cs
+++ b/src/FaunaFinder.Client/Services/Api/ISpeciesService.cs
@@ -31,4 +31,8 @@ public interface ISpeciesService
     Task<CursorPage<SpeciesForSearchDto>> GetSpeciesCursorPageAsync(
         CursorPageRequest request,
         CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SpeciesLocationsDto>> GetSpeciesLocationsBatchAsync(
+        IEnumerable<int> speciesIds,
+        CancellationToken cancellationToken = default);
 }

--- a/src/FaunaFinder.Client/Services/Api/SpeciesApiService.cs
+++ b/src/FaunaFinder.Client/Services/Api/SpeciesApiService.cs
@@ -117,4 +117,15 @@ public sealed class SpeciesApiService : ISpeciesService
 
         return "?" + string.Join("&", queryParams);
     }
+
+    public async Task<IReadOnlyList<SpeciesLocationsDto>> GetSpeciesLocationsBatchAsync(
+        IEnumerable<int> speciesIds,
+        CancellationToken cancellationToken = default)
+    {
+        var ids = string.Join(",", speciesIds);
+        var result = await _httpClient.GetFromJsonAsync<IReadOnlyList<SpeciesLocationsDto>>(
+            $"api/species/locations/batch?ids={ids}",
+            cancellationToken);
+        return result ?? [];
+    }
 }

--- a/src/FaunaFinder.Contracts/Dtos/Species/SpeciesLocationsDto.cs
+++ b/src/FaunaFinder.Contracts/Dtos/Species/SpeciesLocationsDto.cs
@@ -1,0 +1,14 @@
+using FaunaFinder.Contracts.Localization;
+
+namespace FaunaFinder.Contracts.Dtos.Species;
+
+/// <summary>
+/// Represents a species with all of its locations.
+/// Used for batch retrieval of species locations.
+/// </summary>
+public sealed record SpeciesLocationsDto(
+    int Id,
+    List<LocaleValue> CommonName,
+    string ScientificName,
+    List<SpeciesLocationDto> Locations
+);

--- a/src/FaunaFinder.DataAccess/Interfaces/ISpeciesRepository.cs
+++ b/src/FaunaFinder.DataAccess/Interfaces/ISpeciesRepository.cs
@@ -39,4 +39,14 @@ public interface ISpeciesRepository
     Task<CursorPage<SpeciesForSearchDto>> GetSpeciesCursorPageAsync(
         CursorPageRequest request,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all locations for the specified species IDs.
+    /// </summary>
+    /// <param name="speciesIds">The IDs of the species to retrieve locations for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of species with all their locations.</returns>
+    Task<IReadOnlyList<SpeciesLocationsDto>> GetSpeciesLocationsBatchAsync(
+        IEnumerable<int> speciesIds,
+        CancellationToken cancellationToken = default);
 }

--- a/src/FaunaFinder.DataAccess/Repositories/SpeciesRepository.cs
+++ b/src/FaunaFinder.DataAccess/Repositories/SpeciesRepository.cs
@@ -299,4 +299,32 @@ public sealed class SpeciesRepository(
 
         return new CursorPage<SpeciesForSearchDto>(items, nextCursor, hasMore);
     }
+
+    public async Task<IReadOnlyList<SpeciesLocationsDto>> GetSpeciesLocationsBatchAsync(
+        IEnumerable<int> speciesIds,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var ids = speciesIds.ToList();
+
+        return await context.Species
+            .AsNoTracking()
+            .Where(s => ids.Contains(s.Id))
+            .Select(s => new SpeciesLocationsDto(
+                s.Id,
+                s.CommonName.ToList(),
+                s.ScientificName,
+                s.Locations
+                    .Select(l => new SpeciesLocationDto(
+                        l.Id,
+                        l.Latitude,
+                        l.Longitude,
+                        l.RadiusMeters,
+                        l.Description
+                    ))
+                    .ToList()
+            ))
+            .ToListAsync(cancellationToken);
+    }
 }


### PR DESCRIPTION
## Summary
- Fixed issue where clicking "Show Locations" in Near Me mode didn't visibly show the colored location circles
- The colored circles were being added on top of the existing green nearby species markers, causing them to overlap and blend together
- Now clears the green markers before showing colored circles, and restores them when hiding

## Test plan
- [ ] Activate the "Species Near Me" feature by clicking the locate button
- [ ] After nearby species are found, click the "Show Locations" button
- [ ] Verify that colored circles now appear clearly on the map (not blended with green)
- [ ] Click "Hide Locations" and verify the green nearby species markers are restored
- [ ] Change the search radius and verify markers update correctly

Fixes #84