### PR TITLE
Fix mobile close button hidden behind navbar

### DIFF
--- a/src/FaunaFinder.Api/wwwroot/css/app.css
+++ b/src/FaunaFinder.Api/wwwroot/css/app.css
@@ -341,6 +341,7 @@ code {
     display: flex;
     align-items: center;
     padding: 12px 4px 12px 0;
+    padding-top: 56px; /* Account for navbar (48px) + extra spacing on mobile */
     border-bottom: 1px solid var(--mud-palette-lines-default);
     position: sticky;
     top: 0;


### PR DESCRIPTION
## Summary
- Added top padding (56px) to `.mobile-sheet-header` CSS class to ensure the close button (X) is visible below the navbar on mobile devices
- The padding accounts for the navbar height (48px) plus extra spacing for comfortable touch targets

## Test plan
- [ ] Open the app on a mobile device or mobile viewport
- [ ] Click on any municipality to open the bottom sheet
- [ ] Verify the close button (X) is now visible and not hidden behind the navbar
- [ ] Test that the desktop sidebar layout is not affected

Fixes #86