### PR TITLE
Use safe-area-inset for mobile close button spacing

### DIFF
--- a/src/FaunaFinder.Api/Components/App.razor
+++ b/src/FaunaFinder.Api/Components/App.razor
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>FaunaFinder - Puerto Rico</title>
     <base href="/" />
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />

--- a/src/FaunaFinder.Api/wwwroot/css/app.css
+++ b/src/FaunaFinder.Api/wwwroot/css/app.css
@@ -341,7 +341,7 @@ code {
     display: flex;
     align-items: center;
     padding: 12px 4px 12px 0;
-    padding-top: 56px; /* Account for navbar (48px) + extra spacing on mobile */
+    padding-top: calc(env(safe-area-inset-top, 0px) + 64px); /* Safe area for notches + navbar (48px) + extra spacing */
     border-bottom: 1px solid var(--mud-palette-lines-default);
     position: sticky;
     top: 0;


### PR DESCRIPTION
## Summary
- Updated `.mobile-sheet-header` padding to use `calc(env(safe-area-inset-top, 0px) + 64px)` for proper device-safe spacing
- Added `viewport-fit=cover` to the viewport meta tag to enable safe-area-inset support
- Increased base padding from 56px to 64px for additional breathing room on devices without notches

## Test plan
- [ ] Test on Samsung S20 to verify close button is fully visible
- [ ] Test on iPhone with notch to verify safe-area-inset is respected
- [ ] Test on desktop browser to verify no visual regression

Fixes #89