### PR TITLE
Add loading state indicator to map

### DIFF
--- a/src/FaunaFinder.Api/wwwroot/js/leafletInterop.ts
+++ b/src/FaunaFinder.Api/wwwroot/js/leafletInterop.ts
@@ -477,6 +477,9 @@ window.leafletInterop = {
             }).addTo(self.map!);
 
             console.log('GeoJSON loaded successfully with', data.features.length, 'features');
+
+            // Notify Blazor that the map is fully loaded
+            self.dotNetHelper?.invokeMethodAsync('OnMapReady');
         };
 
         // Check localStorage cache first

--- a/src/FaunaFinder.Client/Pages/Home.razor
+++ b/src/FaunaFinder.Client/Pages/Home.razor
@@ -13,7 +13,16 @@
 <PageTitle>@L["PageTitle_Map"]</PageTitle>
 
 <div class="map-page">
-    <div class="map-container">
+    <div class="map-container" style="position: relative;">
+        @if (isMapLoading)
+        {
+            <MudOverlay Visible="true" DarkBackground="false" Absolute="true" Class="map-loading-overlay" ZIndex="1000">
+                <MudStack AlignItems="AlignItems.Center">
+                    <MudProgressCircular Indeterminate="true" Color="Color.Primary" />
+                    <MudText Typo="Typo.body2">@L["Map_Loading"]</MudText>
+                </MudStack>
+            </MudOverlay>
+        }
         <div id="map" class="map"></div>
     </div>
 
@@ -475,6 +484,9 @@
     private bool sidebarOpen = true;
     private int? expandedSpeciesId;
 
+    // Map loading state
+    private bool isMapLoading = true;
+
     // Sort and Filter state
     private SortOption currentSort = SortOption.NameAZ;
     private HashSet<string> selectedNrcsPractices = new();
@@ -714,6 +726,13 @@
             currentLocationIndex++;
             await FocusOnLocation(currentLocationIndex);
         }
+    }
+
+    [JSInvokable]
+    public void OnMapReady()
+    {
+        isMapLoading = false;
+        StateHasChanged();
     }
 
     [JSInvokable]

--- a/src/FaunaFinder.Client/Services/Localization/Translations.cs
+++ b/src/FaunaFinder.Client/Services/Localization/Translations.cs
@@ -30,6 +30,7 @@ public static class Translations
         ["MunicipalityNotFound"] = "Municipality '{0}' not found in database.",
 
         // Map Page
+        ["Map_Loading"] = "Loading map...",
         ["Map_ClickMunicipality"] = "Click on a municipality on the map to view species and conservation information.",
         ["Map_NoSpeciesData"] = "No species data available for this municipality.",
         ["Map_SpeciesFound"] = "{0} species found",
@@ -149,6 +150,7 @@ public static class Translations
         ["MunicipalityNotFound"] = "Municipio '{0}' no encontrado en la base de datos.",
 
         // Map Page
+        ["Map_Loading"] = "Cargando mapa...",
         ["Map_ClickMunicipality"] = "Haz clic en un municipio en el mapa para ver información sobre especies y conservación.",
         ["Map_NoSpeciesData"] = "No hay datos de especies disponibles para este municipio.",
         ["Map_SpeciesFound"] = "{0} especies encontradas",


### PR DESCRIPTION
## Summary
- Add loading overlay with spinner to map while initializing
- Notify Blazor when map and GeoJSON are ready via OnMapReady callback
- Add localization keys for "Loading map..." in English and Spanish

## Test plan
- [ ] Verify loading spinner appears when map page loads
- [ ] Confirm loading overlay hides after GeoJSON loads
- [ ] Test in both English and Spanish locales

Fixes #91