### PR TITLE
Fix NullReferenceException in GetLocalizedValue

### DIFF
--- a/src/FaunaFinder.Client/Services/Localization/AppLocalizer.cs
+++ b/src/FaunaFinder.Client/Services/Localization/AppLocalizer.cs
@@ -32,8 +32,9 @@ public sealed class AppLocalizer : IAppLocalizer
 
     public string GetLocalizedValue(IEnumerable<LocaleValue> values)
     {
+        if (values is null) return string.Empty;
         var targetLocale = IsSpanish ? SupportedLocales.Spanish : SupportedLocales.English;
-        var value = values.FirstOrDefault(v => v.Code.StartsWith(targetLocale));
+        var value = values.FirstOrDefault(v => v.Code?.StartsWith(targetLocale) ?? false);
         return value?.Value ?? values.FirstOrDefault()?.Value ?? string.Empty;
     }
 }


### PR DESCRIPTION
## Summary
- Add null check for `values` parameter
- Add null-conditional operator for `LocaleValue.Code` property

Closes #95

## Test plan
- [ ] Verify species list page loads without errors
- [ ] Verify species detail page loads without errors
