### PR TITLE
Improve SpeciesExpansionPanel title layout and readability

### DIFF
--- a/src/FaunaFinder.Client/Components/SpeciesExpansionPanel.razor
+++ b/src/FaunaFinder.Client/Components/SpeciesExpansionPanel.razor
@@ -4,15 +4,13 @@
                    ExpandedChanged="@OnExpandedChanged"
                    Class="mb-2">
     <TitleContent>
-        <div class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between" style="width: 100%;">
-            <div class="d-flex flex-column flex-sm-row align-start align-sm-center">
-                <MudText Typo="@TitleTypo" Color="Color.Primary">
-                    @L.GetLocalizedValue(Species.CommonName)
-                </MudText>
-                <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    <em>@Species.ScientificName</em>
-                </MudText>
-            </div>
+        <div class="d-flex flex-column">
+            <MudText Typo="@TitleTypo" Color="Color.Primary" Style="font-weight: 600;">
+                @L.GetLocalizedValue(Species.CommonName)
+            </MudText>
+            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1" Style="font-style: italic;">
+                @Species.ScientificName
+            </MudText>
         </div>
     </TitleContent>
     <ChildContent>


### PR DESCRIPTION
## Summary
- Stack common name and scientific name vertically for better readability
- Add font-weight to make common name more prominent as the primary identifier
- Add proper spacing (margin) between names
- Apply italic style to scientific name for visual hierarchy
- Simplify flex layout structure for cleaner markup

Closes #107

## Test plan
- [ ] Verify species panels display common name prominently on first line
- [ ] Verify scientific name appears below in smaller, italic, muted text
- [ ] Test on desktop and mobile viewports to ensure layout looks good
- [ ] Confirm spacing between names is adequate for readability