### PR TITLE
Add Wildlife Discovery API endpoints

### DIFF
--- a/FaunaFinder.sln
+++ b/FaunaFinder.sln
@@ -35,6 +35,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FaunaFinder.Identity.Applic
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FaunaFinder.Identity.Api", "src\Features\Identity\FaunaFinder.Identity.Api\FaunaFinder.Identity.Api.csproj", "{7B21EBA9-527B-4FE5-9DF7-42D8D2E4E3E5}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Features", "Features", "{9792E6E2-564B-9699-7DA2-9F7194AE82F6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WildlifeDiscovery", "WildlifeDiscovery", "{FDA8FDF1-D876-E855-A9A2-80088BB07443}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FaunaFinder.WildlifeDiscovery.Api", "src\Features\WildlifeDiscovery\FaunaFinder.WildlifeDiscovery.Api\FaunaFinder.WildlifeDiscovery.Api.csproj", "{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -201,6 +207,18 @@ Global
 		{7B21EBA9-527B-4FE5-9DF7-42D8D2E4E3E5}.Release|x64.Build.0 = Release|Any CPU
 		{7B21EBA9-527B-4FE5-9DF7-42D8D2E4E3E5}.Release|x86.ActiveCfg = Release|Any CPU
 		{7B21EBA9-527B-4FE5-9DF7-42D8D2E4E3E5}.Release|x86.Build.0 = Release|Any CPU
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}.Debug|x86.Build.0 = Debug|Any CPU
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}.Release|x64.Build.0 = Release|Any CPU
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -214,5 +232,7 @@ Global
 		{A8788E94-FA12-420F-9D3E-27A6E6802AFE} = {E2A5EC54-41E6-334C-DB30-5D71ABDE06FE}
 		{088B16D7-0613-435C-AB4E-C64BC5C46E03} = {E2A5EC54-41E6-334C-DB30-5D71ABDE06FE}
 		{7B21EBA9-527B-4FE5-9DF7-42D8D2E4E3E5} = {E2A5EC54-41E6-334C-DB30-5D71ABDE06FE}
+		{FDA8FDF1-D876-E855-A9A2-80088BB07443} = {9792E6E2-564B-9699-7DA2-9F7194AE82F6}
+		{A1A884FD-BAA1-42B0-8520-EF9D25CBA1CE} = {FDA8FDF1-D876-E855-A9A2-80088BB07443}
 	EndGlobalSection
 EndGlobal

--- a/src/FaunaFinder.Api/FaunaFinder.Api.csproj
+++ b/src/FaunaFinder.Api/FaunaFinder.Api.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\FaunaFinder.Pagination.Contracts\FaunaFinder.Pagination.Contracts.csproj" />
     <ProjectReference Include="..\FaunaFinder.ServiceDefaults\FaunaFinder.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Features\Identity\FaunaFinder.Identity.Api\FaunaFinder.Identity.Api.csproj" />
+    <ProjectReference Include="..\Features\WildlifeDiscovery\FaunaFinder.WildlifeDiscovery.Api\FaunaFinder.WildlifeDiscovery.Api.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/FaunaFinder.Api/Program.cs
+++ b/src/FaunaFinder.Api/Program.cs
@@ -7,6 +7,7 @@ using FaunaFinder.Database.Extensions;
 using FaunaFinder.Database.Models.Users;
 using FaunaFinder.DataAccess.Extensions;
 using FaunaFinder.Identity.Api;
+using FaunaFinder.WildlifeDiscovery.Api;
 using Microsoft.AspNetCore.Identity;
 using QuestPDF.Infrastructure;
 
@@ -84,6 +85,7 @@ api.MapSpeciesEndpoints();
 api.MapSpeciesImageEndpoints();
 api.MapExportEndpoints();
 api.MapIdentityEndpoints();
+api.MapWildlifeDiscoveryEndpoints();
 
 // Serve App.razor as the shell with WASM interactivity
 app.MapRazorComponents<App>()

--- a/src/Features/WildlifeDiscovery/FaunaFinder.WildlifeDiscovery.Api/FaunaFinder.WildlifeDiscovery.Api.csproj
+++ b/src/Features/WildlifeDiscovery/FaunaFinder.WildlifeDiscovery.Api/FaunaFinder.WildlifeDiscovery.Api.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\FaunaFinder.Database\FaunaFinder.Database.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Features/WildlifeDiscovery/FaunaFinder.WildlifeDiscovery.Api/WildlifeDiscoveryEndpoints.cs
+++ b/src/Features/WildlifeDiscovery/FaunaFinder.WildlifeDiscovery.Api/WildlifeDiscoveryEndpoints.cs
@@ -1,0 +1,473 @@
+using FaunaFinder.Contracts.Localization;
+using FaunaFinder.Database;
+using FaunaFinder.Database.Models.Sightings;
+using FaunaFinder.Database.Models.Users;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using NetTopologySuite.Geometries;
+
+namespace FaunaFinder.WildlifeDiscovery.Api;
+
+public static class WildlifeDiscoveryEndpoints
+{
+    public static IEndpointRouteBuilder MapWildlifeDiscoveryEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/wildlife")
+            .WithTags("Wildlife Discovery");
+
+        // Public endpoints
+        group.MapGet("/species/search", SearchSpecies)
+            .WithName("SearchSpecies");
+
+        group.MapGet("/sightings/{id:int}/photo", GetSightingPhoto)
+            .WithName("GetSightingPhoto");
+
+        // Authenticated endpoints
+        group.MapPost("/sightings", CreateSighting)
+            .RequireAuthorization()
+            .DisableAntiforgery()
+            .WithName("CreateSighting");
+
+        group.MapGet("/sightings", GetSightings)
+            .RequireAuthorization()
+            .WithName("GetSightings");
+
+        group.MapGet("/sightings/{id:int}", GetSightingDetail)
+            .RequireAuthorization()
+            .WithName("GetSightingDetail");
+
+        group.MapGet("/my-sightings", GetMySightings)
+            .RequireAuthorization()
+            .WithName("GetMySightings");
+
+        // Teacher/Admin endpoints
+        group.MapPost("/sightings/{id:int}/review", ReviewSighting)
+            .RequireAuthorization()
+            .WithName("ReviewSighting");
+
+        group.MapGet("/review-queue", GetReviewQueue)
+            .RequireAuthorization()
+            .WithName("GetReviewQueue");
+
+        return app;
+    }
+
+    private static async Task<IResult> SearchSpecies(
+        string? query,
+        int limit,
+        FaunaFinderContext db,
+        CancellationToken ct)
+    {
+        if (limit <= 0) limit = 10;
+        if (limit > 50) limit = 50;
+
+        var speciesQuery = db.Species.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            var search = query.ToLowerInvariant();
+            speciesQuery = speciesQuery.Where(s =>
+                s.CommonName.Any(cn => cn.Value.ToLower().Contains(search)) ||
+                s.ScientificName.ToLower().Contains(search));
+        }
+
+        var species = await speciesQuery
+            .OrderBy(s => s.ScientificName)
+            .Take(limit)
+            .Select(s => new
+            {
+                s.Id,
+                CommonName = s.CommonName.ToList(),
+                s.ScientificName
+            })
+            .ToListAsync(ct);
+
+        return Results.Ok(species);
+    }
+
+    private static async Task<IResult> CreateSighting(
+        HttpContext context,
+        UserManager<User> userManager,
+        FaunaFinderContext db,
+        IFormFile? photo,
+        int speciesId,
+        double latitude,
+        double longitude,
+        DateTime observedAt,
+        string mode,
+        string confidence,
+        string count,
+        int behaviors,
+        int evidence,
+        string? weather,
+        string? notes,
+        CancellationToken ct)
+    {
+        var user = await userManager.GetUserAsync(context.User);
+        if (user is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        // Validate species exists
+        var speciesExists = await db.Species.AnyAsync(s => s.Id == speciesId, ct);
+        if (!speciesExists)
+        {
+            return Results.BadRequest("Invalid species ID");
+        }
+
+        // Parse enums
+        if (!Enum.TryParse<SightingMode>(mode, true, out var sightingMode))
+        {
+            return Results.BadRequest("Invalid mode");
+        }
+
+        if (!Enum.TryParse<ConfidenceLevel>(confidence, true, out var confidenceLevel))
+        {
+            return Results.BadRequest("Invalid confidence level");
+        }
+
+        if (!Enum.TryParse<CountRange>(count, true, out var countRange))
+        {
+            return Results.BadRequest("Invalid count range");
+        }
+
+        Weather? weatherEnum = null;
+        if (!string.IsNullOrWhiteSpace(weather))
+        {
+            if (!Enum.TryParse<Weather>(weather, true, out var parsedWeather))
+            {
+                return Results.BadRequest("Invalid weather");
+            }
+            weatherEnum = parsedWeather;
+        }
+
+        // Process photo if provided
+        byte[]? photoData = null;
+        string? photoContentType = null;
+        if (photo is not null && photo.Length > 0)
+        {
+            var allowedContentTypes = new[] { "image/jpeg", "image/png", "image/gif", "image/webp" };
+            if (!allowedContentTypes.Contains(photo.ContentType.ToLower()))
+            {
+                return Results.BadRequest("Invalid image type. Allowed types: JPEG, PNG, GIF, WebP");
+            }
+
+            using var memoryStream = new MemoryStream();
+            await photo.CopyToAsync(memoryStream, ct);
+            photoData = memoryStream.ToArray();
+            photoContentType = photo.ContentType;
+        }
+
+        // Create the sighting
+        var sighting = new Sighting
+        {
+            Id = 0,
+            SpeciesId = speciesId,
+            UserSpeciesId = null,
+            Mode = sightingMode,
+            Confidence = confidenceLevel,
+            Count = countRange,
+            Behaviors = (Behavior)behaviors,
+            Evidence = (EvidenceType)evidence,
+            Weather = weatherEnum,
+            Notes = notes,
+            Location = new Point(longitude, latitude) { SRID = 4326 },
+            MunicipalityId = null,
+            ObservedAt = observedAt,
+            CreatedAt = DateTime.UtcNow,
+            PhotoData = photoData,
+            PhotoContentType = photoContentType,
+            AudioData = null,
+            AudioContentType = null,
+            Status = SightingStatus.Pending,
+            IsFlaggedForReview = false,
+            IsNewMunicipalityRecord = false,
+            ReviewNotes = null,
+            ReviewedAt = null,
+            ReviewedByUserId = null,
+            ReportedByUserId = user.Id
+        };
+
+        db.Sightings.Add(sighting);
+        await db.SaveChangesAsync(ct);
+
+        return Results.Created($"/wildlife/sightings/{sighting.Id}", new { sighting.Id });
+    }
+
+    private static async Task<IResult> GetSightings(
+        int pageSize,
+        int page,
+        string? status,
+        FaunaFinderContext db,
+        CancellationToken ct)
+    {
+        if (pageSize <= 0) pageSize = 20;
+        if (pageSize > 100) pageSize = 100;
+        if (page < 1) page = 1;
+
+        var query = db.Sightings.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(status) && Enum.TryParse<SightingStatus>(status, true, out var statusFilter))
+        {
+            query = query.Where(s => s.Status == statusFilter);
+        }
+
+        var totalCount = await query.CountAsync(ct);
+
+        var sightings = await query
+            .OrderByDescending(s => s.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(s => new
+            {
+                s.Id,
+                s.SpeciesId,
+                SpeciesName = s.Species != null ? s.Species.CommonName : null,
+                s.Mode,
+                s.Confidence,
+                s.Count,
+                s.Status,
+                s.ObservedAt,
+                s.CreatedAt,
+                Latitude = s.Location.Y,
+                Longitude = s.Location.X,
+                HasPhoto = s.PhotoData != null,
+                ReportedByUserName = s.ReportedByUser != null ? s.ReportedByUser.DisplayName : null
+            })
+            .ToListAsync(ct);
+
+        return Results.Ok(new
+        {
+            Items = sightings,
+            TotalCount = totalCount,
+            Page = page,
+            PageSize = pageSize
+        });
+    }
+
+    private static async Task<IResult> GetSightingDetail(
+        int id,
+        FaunaFinderContext db,
+        CancellationToken ct)
+    {
+        var sighting = await db.Sightings
+            .Include(s => s.Species)
+            .Include(s => s.ReportedByUser)
+            .Include(s => s.ReviewedByUser)
+            .Include(s => s.Municipality)
+            .FirstOrDefaultAsync(s => s.Id == id, ct);
+
+        if (sighting is null)
+        {
+            return Results.NotFound();
+        }
+
+        return Results.Ok(new
+        {
+            sighting.Id,
+            sighting.SpeciesId,
+            SpeciesName = sighting.Species?.CommonName,
+            SpeciesScientificName = sighting.Species?.ScientificName,
+            sighting.Mode,
+            sighting.Confidence,
+            sighting.Count,
+            sighting.Behaviors,
+            sighting.Evidence,
+            sighting.Weather,
+            sighting.Notes,
+            Latitude = sighting.Location.Y,
+            Longitude = sighting.Location.X,
+            sighting.MunicipalityId,
+            MunicipalityName = sighting.Municipality?.Name,
+            sighting.ObservedAt,
+            sighting.CreatedAt,
+            HasPhoto = sighting.PhotoData != null,
+            sighting.Status,
+            sighting.IsFlaggedForReview,
+            sighting.IsNewMunicipalityRecord,
+            sighting.ReviewNotes,
+            sighting.ReviewedAt,
+            ReviewedByUserName = sighting.ReviewedByUser?.DisplayName,
+            sighting.ReportedByUserId,
+            ReportedByUserName = sighting.ReportedByUser?.DisplayName
+        });
+    }
+
+    private static async Task<IResult> GetSightingPhoto(
+        int id,
+        FaunaFinderContext db,
+        CancellationToken ct)
+    {
+        var sighting = await db.Sightings
+            .Where(s => s.Id == id)
+            .Select(s => new { s.PhotoData, s.PhotoContentType })
+            .FirstOrDefaultAsync(ct);
+
+        if (sighting?.PhotoData is null || sighting.PhotoContentType is null)
+        {
+            return Results.NotFound();
+        }
+
+        return Results.File(sighting.PhotoData, sighting.PhotoContentType);
+    }
+
+    private static async Task<IResult> ReviewSighting(
+        int id,
+        HttpContext context,
+        UserManager<User> userManager,
+        FaunaFinderContext db,
+        string status,
+        string? reviewNotes,
+        CancellationToken ct)
+    {
+        var user = await userManager.GetUserAsync(context.User);
+        if (user is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        // Check if user is Teacher or Admin
+        if (user.Role != UserRole.Teacher && user.Role != UserRole.Admin)
+        {
+            return Results.Forbid();
+        }
+
+        if (!Enum.TryParse<SightingStatus>(status, true, out var newStatus))
+        {
+            return Results.BadRequest("Invalid status");
+        }
+
+        var sighting = await db.Sightings.FindAsync([id], ct);
+        if (sighting is null)
+        {
+            return Results.NotFound();
+        }
+
+        sighting.Status = newStatus;
+        sighting.ReviewNotes = reviewNotes;
+        sighting.ReviewedAt = DateTime.UtcNow;
+        sighting.ReviewedByUserId = user.Id;
+
+        await db.SaveChangesAsync(ct);
+
+        return Results.Ok(new { sighting.Id, sighting.Status });
+    }
+
+    private static async Task<IResult> GetReviewQueue(
+        HttpContext context,
+        UserManager<User> userManager,
+        FaunaFinderContext db,
+        int pageSize,
+        int page,
+        CancellationToken ct)
+    {
+        var user = await userManager.GetUserAsync(context.User);
+        if (user is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        // Check if user is Teacher or Admin
+        if (user.Role != UserRole.Teacher && user.Role != UserRole.Admin)
+        {
+            return Results.Forbid();
+        }
+
+        if (pageSize <= 0) pageSize = 20;
+        if (pageSize > 100) pageSize = 100;
+        if (page < 1) page = 1;
+
+        var query = db.Sightings
+            .Where(s => s.Status == SightingStatus.Pending);
+
+        var totalCount = await query.CountAsync(ct);
+
+        var sightings = await query
+            .OrderBy(s => s.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(s => new
+            {
+                s.Id,
+                s.SpeciesId,
+                SpeciesName = s.Species != null ? s.Species.CommonName : null,
+                s.Mode,
+                s.Confidence,
+                s.Count,
+                s.ObservedAt,
+                s.CreatedAt,
+                Latitude = s.Location.Y,
+                Longitude = s.Location.X,
+                HasPhoto = s.PhotoData != null,
+                s.IsFlaggedForReview,
+                s.IsNewMunicipalityRecord,
+                ReportedByUserName = s.ReportedByUser != null ? s.ReportedByUser.DisplayName : null
+            })
+            .ToListAsync(ct);
+
+        return Results.Ok(new
+        {
+            Items = sightings,
+            TotalCount = totalCount,
+            Page = page,
+            PageSize = pageSize
+        });
+    }
+
+    private static async Task<IResult> GetMySightings(
+        HttpContext context,
+        UserManager<User> userManager,
+        FaunaFinderContext db,
+        int pageSize,
+        int page,
+        CancellationToken ct)
+    {
+        var user = await userManager.GetUserAsync(context.User);
+        if (user is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (pageSize <= 0) pageSize = 20;
+        if (pageSize > 100) pageSize = 100;
+        if (page < 1) page = 1;
+
+        var query = db.Sightings
+            .Where(s => s.ReportedByUserId == user.Id);
+
+        var totalCount = await query.CountAsync(ct);
+
+        var sightings = await query
+            .OrderByDescending(s => s.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(s => new
+            {
+                s.Id,
+                s.SpeciesId,
+                SpeciesName = s.Species != null ? s.Species.CommonName : null,
+                s.Mode,
+                s.Confidence,
+                s.Count,
+                s.Status,
+                s.ObservedAt,
+                s.CreatedAt,
+                Latitude = s.Location.Y,
+                Longitude = s.Location.X,
+                HasPhoto = s.PhotoData != null
+            })
+            .ToListAsync(ct);
+
+        return Results.Ok(new
+        {
+            Items = sightings,
+            TotalCount = totalCount,
+            Page = page,
+            PageSize = pageSize
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Adds REST API endpoints for wildlife sighting management under `/api/wildlife`
- Implements species autocomplete search with localized name support
- Provides sighting CRUD operations with photo upload capability
- Includes review workflow endpoints restricted to Teacher/Admin roles

## Endpoints

| Endpoint | Auth | Description |
|----------|------|-------------|
| `GET /wildlife/species/search` | Public | Species autocomplete |
| `POST /wildlife/sightings` | Required | Create sighting |
| `GET /wildlife/sightings` | Required | List sightings |
| `GET /wildlife/sightings/{id}` | Required | Get sighting detail |
| `GET /wildlife/sightings/{id}/photo` | Public | Download photo |
| `POST /wildlife/sightings/{id}/review` | Teacher/Admin | Review sighting |
| `GET /wildlife/review-queue` | Teacher/Admin | Get review queue |
| `GET /wildlife/my-sightings` | Required | Get user's own sightings |

## Test plan
- [ ] Verify solution builds without errors
- [ ] Test species search endpoint returns matching results
- [ ] Test sighting creation with and without photo
- [ ] Test authorization on protected endpoints
- [ ] Test Teacher/Admin role restrictions on review endpoints

Closes #119
