### PR TITLE
Add CLAUDE.md and skills.md for AI integration

### DIFF
--- a/.claude/skills.md
+++ b/.claude/skills.md
@@ -1,0 +1,240 @@
+# FaunaFinder Custom Skills
+
+## /feature
+
+Scaffold a new feature with all required projects following the vertical slice architecture.
+
+### Usage
+```
+/feature {FeatureName}
+```
+
+### Creates
+```
+src/Features/{Feature}/
+├── FaunaFinder.{Feature}.Api/
+│   ├── {Feature}Endpoints.cs
+│   ├── DependencyInjection.cs
+│   └── FaunaFinder.{Feature}.Api.csproj
+├── FaunaFinder.{Feature}.Application/
+│   ├── Services/
+│   ├── DependencyInjection.cs
+│   └── FaunaFinder.{Feature}.Application.csproj
+├── FaunaFinder.{Feature}.Application.Client/
+│   ├── I{Feature}Client.cs
+│   ├── {Feature}Client.cs
+│   ├── DependencyInjection.cs
+│   └── FaunaFinder.{Feature}.Application.Client.csproj
+├── FaunaFinder.{Feature}.Contracts/
+│   ├── Requests/
+│   ├── Responses/
+│   └── FaunaFinder.{Feature}.Contracts.csproj
+├── FaunaFinder.{Feature}.Database/
+│   ├── Models/
+│   ├── {Feature}DbContext.cs
+│   └── FaunaFinder.{Feature}.Database.csproj
+└── FaunaFinder.{Feature}.DataAccess/
+    ├── Repositories/
+    ├── DependencyInjection.cs
+    └── FaunaFinder.{Feature}.DataAccess.csproj
+```
+
+### Steps
+1. Create all project directories and .csproj files
+2. Add projects to solution with `dotnet sln add`
+3. Set up project references following dependency flow
+4. Create placeholder files with correct namespaces
+5. Register feature in FaunaFinder.Api Program.cs
+6. Register client in FaunaFinder.Client Program.cs
+7. Add database to AppHost
+
+---
+
+## /endpoint
+
+Add a new API endpoint to an existing feature.
+
+### Usage
+```
+/endpoint {Feature} {EndpointName} {HttpMethod}
+```
+
+### Example
+```
+/endpoint Wildlife GetSpeciesById GET
+```
+
+### Steps
+1. Add endpoint method to `{Feature}Endpoints.cs`
+2. Create request/response DTOs in Contracts if needed
+3. Add service method in Application layer
+4. Add repository method in DataAccess if needed
+5. Wire up dependencies
+
+---
+
+## /migration
+
+Create a new EF Core migration for a feature.
+
+### Usage
+```
+/migration {Feature} {MigrationName}
+```
+
+### Example
+```
+/migration Wildlife AddSightingAuditFields
+```
+
+### Command
+```bash
+dotnet ef migrations add {MigrationName} \
+  --project src/Features/{Feature}/FaunaFinder.{Feature}.Database \
+  --startup-project src/FaunaFinder.Api
+```
+
+---
+
+## /component
+
+Create a new Blazor component.
+
+### Usage
+```
+/component {Feature} {ComponentName}
+```
+
+### Example
+```
+/component Wildlife SightingCard
+```
+
+### Creates
+```
+src/FaunaFinder.Client/Pages/{Feature}/{ComponentName}.razor
+```
+
+### Template
+- Includes `@inject IAppLocalizer L`
+- Uses MudBlazor components
+- Follows existing component patterns
+
+---
+
+## /page
+
+Create a new Blazor page with route.
+
+### Usage
+```
+/page {Feature} {PageName} {Route}
+```
+
+### Example
+```
+/page Wildlife SightingDetails /sightings/{id:int}
+```
+
+### Creates
+```
+src/FaunaFinder.Client/Pages/{Feature}/{PageName}.razor
+```
+
+### Template
+- Includes `@page "{Route}"`
+- Includes `@attribute [Authorize]` if authenticated
+- Injects required services
+- Uses MudBlazor layout components
+
+---
+
+## /repository
+
+Add a new repository to a feature's DataAccess layer.
+
+### Usage
+```
+/repository {Feature} {EntityName}
+```
+
+### Example
+```
+/repository Wildlife Species
+```
+
+### Creates
+- `I{Entity}Repository.cs` - Interface
+- `{Entity}Repository.cs` - Implementation
+
+### Rules
+- Returns DTOs from Contracts, not entities
+- Registered in DependencyInjection.cs
+
+---
+
+## /service
+
+Add a new service to a feature's Application layer.
+
+### Usage
+```
+/service {Feature} {ServiceName}
+```
+
+### Example
+```
+/service Wildlife SightingReview
+```
+
+### Creates
+- `I{ServiceName}Service.cs` - Interface
+- `{ServiceName}Service.cs` - Implementation
+
+### Rules
+- Uses repositories from DataAccess
+- Returns DTOs from Contracts
+- Registered in DependencyInjection.cs
+
+---
+
+## /dto
+
+Create a new DTO in Contracts.
+
+### Usage
+```
+/dto {Feature} {DtoName} {Type}
+```
+
+Where `{Type}` is: `request`, `response`, or `shared`
+
+### Example
+```
+/dto Wildlife CreateSighting request
+```
+
+### Creates
+- For `request`: `Requests/{DtoName}Request.cs` + `{DtoName}RequestValidator.cs`
+- For `response`: `Responses/{DtoName}Response.cs`
+- For `shared`: `{DtoName}.cs`
+
+---
+
+## /translate
+
+Add a new translation key to both API and Client.
+
+### Usage
+```
+/translate {Key} {English} {Spanish}
+```
+
+### Example
+```
+/translate Sighting_Submit "Submit Report" "Enviar Reporte"
+```
+
+### Updates
+- `src/FaunaFinder.Api/Services/Localization/Translations.cs`
+- `src/FaunaFinder.Client/Services/Localization/Translations.cs`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# FaunaFinder - Claude Code Context
+
+## Project Overview
+
+FaunaFinder is a wildlife observation and reporting platform for Puerto Rico. Students can report wildlife sightings, and teachers can review and approve them.
+
+## Tech Stack
+
+- **Backend**: .NET 10, Minimal APIs
+- **Frontend**: Blazor WebAssembly
+- **UI Components**: MudBlazor
+- **Database**: PostgreSQL with EF Core
+- **Orchestration**: .NET Aspire
+- **Localization**: Custom i18n with Spanish/English support
+
+## Architecture
+
+Vertical slice / modular monolith architecture. Each feature is isolated and could be extracted into a microservice.
+
+### Feature Structure
+
+```
+src/Features/{Feature}/
+├── FaunaFinder.{Feature}.Api/              # Minimal API endpoints
+├── FaunaFinder.{Feature}.Application/       # Business logic, services
+├── FaunaFinder.{Feature}.Application.Client/ # HTTP client for Blazor WASM
+├── FaunaFinder.{Feature}.Contracts/         # DTOs, requests, responses, validators (ZERO dependencies)
+├── FaunaFinder.{Feature}.Database/          # Models, DbContext, migrations
+└── FaunaFinder.{Feature}.DataAccess/        # Repositories (return DTOs, not entities)
+```
+
+### Key Rules
+
+- `.Contracts` projects have NO project dependencies (usable by WASM)
+- Repositories return DTOs from Contracts, not entities
+- Cross-feature references by ID only (no navigation properties)
+- Each feature has its own database and DbContext
+
+### Current Features
+
+- **Identity** - Authentication, user management
+- **Wildlife** - Sighting reports, species search, review queue
+
+## Project Structure
+
+```
+src/
+├── Common/                          # Shared contracts (Pagination, i18n)
+├── Features/                        # Feature modules
+├── FaunaFinder.Api/                 # Host application
+├── FaunaFinder.Client/              # Blazor WASM UI
+├── FaunaFinder.AppHost/             # Aspire orchestration
+└── FaunaFinder.ServiceDefaults/     # Shared Aspire config
+```
+
+## Common Commands
+
+```bash
+# Run the application (from repo root)
+dotnet run --project src/FaunaFinder.AppHost
+
+# Build solution
+dotnet build
+
+# Run specific project
+dotnet run --project src/FaunaFinder.Api
+
+# Add migration (replace {Feature} and {MigrationName})
+dotnet ef migrations add {MigrationName} --project src/Features/{Feature}/FaunaFinder.{Feature}.Database
+
+# Update database
+dotnet ef database update --project src/Features/{Feature}/FaunaFinder.{Feature}.Database
+```
+
+## Coding Conventions
+
+### Naming
+
+- Features: PascalCase singular (`Wildlife`, `Identity`)
+- Endpoints: `{Feature}Endpoints.cs`
+- DbContext: `{Feature}DbContext.cs`
+- Repositories: `I{Entity}Repository.cs` / `{Entity}Repository.cs`
+- Client services: `I{Feature}Client.cs` / `{Feature}Client.cs`
+
+### API Endpoints
+
+- Use Minimal APIs with `MapGroup`
+- Group by feature: `/api/{feature}/...`
+- Use `RequireAuthorization()` for protected endpoints
+- Return DTOs from Contracts, not entities
+
+### Blazor Pages
+
+- Located in `FaunaFinder.Client/Pages/{Feature}/`
+- Use `@inject IAppLocalizer L` for translations
+- Use MudBlazor components
+
+### Localization
+
+- Keys format: `{Feature}_{Context}_{Name}` (e.g., `Sighting_Form_Submit`)
+- Add translations to both `FaunaFinder.Api/Services/Localization/Translations.cs` and `FaunaFinder.Client/Services/Localization/Translations.cs`
+
+## Database
+
+- PostgreSQL via Aspire
+- Each feature has its own database
+- Connection strings managed by Aspire
+
+## Git Workflow
+
+- Branch naming: `feature/issue-{number}-{short-description}`
+- Commit messages: Descriptive, no co-author needed
+- PRs target `master` branch


### PR DESCRIPTION
Closes #129

## Summary
- Add `CLAUDE.md` with project overview, architecture, conventions, and common commands
- Add `.claude/skills.md` with custom slash commands for scaffolding

## Custom Skills Added
- `/feature` - Scaffold a new feature with all projects
- `/endpoint` - Add a new API endpoint
- `/migration` - Create EF Core migration
- `/component` - Create Blazor component
- `/page` - Create Blazor page with route
- `/repository` - Add repository to DataAccess
- `/service` - Add service to Application layer
- `/dto` - Create DTO in Contracts
- `/translate` - Add translation keys