### PR TITLE
Rename HTTP client services to use HttpClient suffix

### DIFF
--- a/src/FaunaFinder.Client/Pages/Home.razor
+++ b/src/FaunaFinder.Client/Pages/Home.razor
@@ -1,9 +1,9 @@
 @page "/"
 @using BlazingSingularity.Commands
 @using FaunaFinder.Client.Pages.MapComponents
-@inject IMunicipalityService MunicipalityService
-@inject ISpeciesService SpeciesService
-@inject IExportService ExportService
+@inject IMunicipalityHttpClient MunicipalityHttpClient
+@inject ISpeciesHttpClient SpeciesHttpClient
+@inject IExportHttpClient ExportHttpClient
 @inject ApiConfiguration ApiConfig
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
@@ -610,7 +610,7 @@
         try
         {
             var filteredIds = FilteredSpecies.Select(s => s.Id);
-            var pdfBytes = await ExportService.ExportMunicipalityPdfAsync(selectedMunicipality.Id, filteredIds);
+            var pdfBytes = await ExportHttpClient.ExportMunicipalityPdfAsync(selectedMunicipality.Id, filteredIds);
             var fileName = $"{clickedMunicipalityName?.Replace(" ", "_")}_Species_Report.pdf";
             await DownloadFile(pdfBytes, fileName, "application/pdf");
         }
@@ -631,7 +631,7 @@
         try
         {
             var filteredIds = FilteredSpecies.Select(s => s.Id);
-            var csvBytes = await ExportService.ExportMunicipalityCsvAsync(selectedMunicipality.Id, filteredIds);
+            var csvBytes = await ExportHttpClient.ExportMunicipalityCsvAsync(selectedMunicipality.Id, filteredIds);
             var fileName = $"{clickedMunicipalityName?.Replace(" ", "_")}_Species_Report.csv";
             await DownloadFile(csvBytes, fileName, "text/csv");
         }
@@ -662,7 +662,7 @@
     {
         if (firstRender)
         {
-            municipalities = await MunicipalityService.GetAllMunicipalitiesAsync();
+            municipalities = await MunicipalityHttpClient.GetAllMunicipalitiesAsync();
             await JS.InvokeVoidAsync("leafletInterop.initMap", DotNetObjectReference.Create(this), ApiConfig.BaseAddress);
 
             // Check if we need to show species locations
@@ -680,7 +680,7 @@
 
     private async Task LoadSpeciesLocations(int speciesId)
     {
-        viewingSpeciesLocations = await SpeciesService.GetSpeciesDetailAsync(speciesId);
+        viewingSpeciesLocations = await SpeciesHttpClient.GetSpeciesDetailAsync(speciesId);
         currentLocationIndex = 0;
         if (viewingSpeciesLocations?.Locations.Count > 0)
         {
@@ -797,7 +797,7 @@
     {
         if (selectedMunicipality != null)
         {
-            species = await SpeciesService.GetSpeciesByMunicipalityAsync(selectedMunicipality.Id);
+            species = await SpeciesHttpClient.GetSpeciesByMunicipalityAsync(selectedMunicipality.Id);
         }
     }
 
@@ -876,7 +876,7 @@
             await JS.InvokeVoidAsync("leafletInterop.showSearchRadius", radiusMeters);
 
             // Query nearby species
-            nearbySpecies = await SpeciesService.GetSpeciesNearbyAsync(
+            nearbySpecies = await SpeciesHttpClient.GetSpeciesNearbyAsync(
                 userLatitude.Value,
                 userLongitude.Value,
                 radiusMeters);

--- a/src/FaunaFinder.Client/Pages/PuebloDetail.razor
+++ b/src/FaunaFinder.Client/Pages/PuebloDetail.razor
@@ -1,7 +1,7 @@
 @page "/pueblos/{Id:int}"
 @using BlazingSingularity.Commands
-@inject IMunicipalityService MunicipalityService
-@inject ISpeciesService SpeciesService
+@inject IMunicipalityHttpClient MunicipalityHttpClient
+@inject ISpeciesHttpClient SpeciesHttpClient
 @inject NavigationManager NavigationManager
 @inject IAppLocalizer L
 
@@ -178,7 +178,7 @@
     private async Task LoadMunicipalityAsync()
     {
         isLoadingMunicipality = true;
-        municipality = await MunicipalityService.GetMunicipalityDetailAsync(Id);
+        municipality = await MunicipalityHttpClient.GetMunicipalityDetailAsync(Id);
         isLoadingMunicipality = false;
         StateHasChanged();
     }
@@ -186,7 +186,7 @@
     private async Task LoadSpeciesAsync()
     {
         isLoadingSpecies = true;
-        species = await SpeciesService.GetSpeciesByMunicipalityAsync(Id);
+        species = await SpeciesHttpClient.GetSpeciesByMunicipalityAsync(Id);
         isLoadingSpecies = false;
         StateHasChanged();
     }

--- a/src/FaunaFinder.Client/Pages/Pueblos.razor
+++ b/src/FaunaFinder.Client/Pages/Pueblos.razor
@@ -1,6 +1,6 @@
 @page "/pueblos"
 @implements IDisposable
-@inject IMunicipalityService MunicipalityService
+@inject IMunicipalityHttpClient MunicipalityHttpClient
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
 @inject IAppLocalizer L
@@ -120,7 +120,7 @@
         StateHasChanged();
 
         var request = new CursorPageRequest(nextCursor, PageSize, string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm);
-        var page = await MunicipalityService.GetMunicipalitiesCursorPageAsync(request);
+        var page = await MunicipalityHttpClient.GetMunicipalitiesCursorPageAsync(request);
 
         municipalities.AddRange(page.Items);
         nextCursor = page.NextCursor;

--- a/src/FaunaFinder.Client/Pages/Species.razor
+++ b/src/FaunaFinder.Client/Pages/Species.razor
@@ -1,6 +1,6 @@
 @page "/species"
 @implements IDisposable
-@inject ISpeciesService SpeciesService
+@inject ISpeciesHttpClient SpeciesHttpClient
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
 @inject IAppLocalizer L
@@ -124,7 +124,7 @@
         StateHasChanged();
 
         var request = new CursorPageRequest(nextCursor, PageSize, string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm);
-        var page = await SpeciesService.GetSpeciesCursorPageAsync(request);
+        var page = await SpeciesHttpClient.GetSpeciesCursorPageAsync(request);
 
         species.AddRange(page.Items);
         nextCursor = page.NextCursor;

--- a/src/FaunaFinder.Client/Pages/SpeciesDetail.razor
+++ b/src/FaunaFinder.Client/Pages/SpeciesDetail.razor
@@ -1,6 +1,6 @@
 @page "/species/{Id:int}"
 @using BlazingSingularity.Commands
-@inject ISpeciesService SpeciesService
+@inject ISpeciesHttpClient SpeciesHttpClient
 @inject NavigationManager NavigationManager
 @inject IAppLocalizer L
 
@@ -321,7 +321,7 @@
     [RelayCommand]
     private async Task LoadData()
     {
-        species = await SpeciesService.GetSpeciesDetailAsync(Id);
+        species = await SpeciesHttpClient.GetSpeciesDetailAsync(Id);
     }
 
     private void OnNrcsPracticeChanged(string? value)

--- a/src/FaunaFinder.Client/Pages/Wildlife/MySightings.razor
+++ b/src/FaunaFinder.Client/Pages/Wildlife/MySightings.razor
@@ -1,7 +1,7 @@
 @page "/sightings"
 @using Microsoft.AspNetCore.Authorization
 @using FaunaFinder.Wildlife.Contracts
-@inject IWildlifeService WildlifeService
+@inject IWildlifeHttpClient WildlifeHttpClient
 @inject NavigationManager Navigation
 @inject IAppLocalizer L
 @attribute [Authorize]
@@ -106,7 +106,7 @@
 
         try
         {
-            var response = await WildlifeService.GetMySightingsAsync(_page, PageSize);
+            var response = await WildlifeHttpClient.GetMySightingsAsync(_page, PageSize);
             _sightings = response.Items;
             _totalCount = response.TotalCount;
         }
@@ -131,7 +131,7 @@
 
         try
         {
-            var response = await WildlifeService.GetMySightingsAsync(_page, PageSize);
+            var response = await WildlifeHttpClient.GetMySightingsAsync(_page, PageSize);
             _sightings?.AddRange(response.Items);
         }
         catch

--- a/src/FaunaFinder.Client/Pages/Wildlife/ReportSighting.razor
+++ b/src/FaunaFinder.Client/Pages/Wildlife/ReportSighting.razor
@@ -1,7 +1,7 @@
 @page "/sightings/report"
 @using Microsoft.AspNetCore.Authorization
 @using FaunaFinder.Wildlife.Contracts
-@inject IWildlifeService WildlifeService
+@inject IWildlifeHttpClient WildlifeHttpClient
 @inject NavigationManager Navigation
 @inject IJSRuntime JS
 @inject IAppLocalizer L
@@ -185,7 +185,7 @@
 
         try
         {
-            return await WildlifeService.SearchSpeciesAsync(value, 10, token);
+            return await WildlifeHttpClient.SearchSpeciesAsync(value, 10, token);
         }
         catch
         {
@@ -270,7 +270,7 @@
                 null,
                 null);
 
-            var result = await WildlifeService.CreateSightingAsync(request);
+            var result = await WildlifeHttpClient.CreateSightingAsync(request);
 
             if (result.Success && result.Id.HasValue)
             {

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/DependencyInjection.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/DependencyInjection.cs
@@ -6,22 +6,22 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddWildlifeClient(this IServiceCollection services, Action<HttpClient>? configureClient = null)
     {
-        services.AddHttpClient<IMunicipalityService, MunicipalityApiService>(client =>
+        services.AddHttpClient<IMunicipalityHttpClient, MunicipalityHttpClient>(client =>
         {
             configureClient?.Invoke(client);
         });
 
-        services.AddHttpClient<ISpeciesService, SpeciesApiService>(client =>
+        services.AddHttpClient<ISpeciesHttpClient, SpeciesHttpClient>(client =>
         {
             configureClient?.Invoke(client);
         });
 
-        services.AddHttpClient<IExportService, ExportApiService>(client =>
+        services.AddHttpClient<IExportHttpClient, ExportHttpClient>(client =>
         {
             configureClient?.Invoke(client);
         });
 
-        services.AddHttpClient<IWildlifeService, WildlifeApiService>(client =>
+        services.AddHttpClient<IWildlifeHttpClient, WildlifeHttpClient>(client =>
         {
             configureClient?.Invoke(client);
         });

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/ExportHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/ExportHttpClient.cs
@@ -1,10 +1,10 @@
 namespace FaunaFinder.Wildlife.Application.Client;
 
-public class ExportApiService : IExportService
+public class ExportHttpClient : IExportHttpClient
 {
     private readonly HttpClient _httpClient;
 
-    public ExportApiService(HttpClient httpClient)
+    public ExportHttpClient(HttpClient httpClient)
     {
         _httpClient = httpClient;
     }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IExportHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IExportHttpClient.cs
@@ -1,6 +1,6 @@
 namespace FaunaFinder.Wildlife.Application.Client;
 
-public interface IExportService
+public interface IExportHttpClient
 {
     Task<byte[]> ExportMunicipalityPdfAsync(
         int municipalityId,

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IMunicipalityHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IMunicipalityHttpClient.cs
@@ -4,7 +4,7 @@ using FaunaFinder.Pagination.Contracts;
 
 namespace FaunaFinder.Wildlife.Application.Client;
 
-public interface IMunicipalityService
+public interface IMunicipalityHttpClient
 {
     Task<IReadOnlyList<MunicipalityForListDto>> GetAllMunicipalitiesAsync(
         CancellationToken cancellationToken = default);

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/ISpeciesHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/ISpeciesHttpClient.cs
@@ -4,7 +4,7 @@ using FaunaFinder.Pagination.Contracts;
 
 namespace FaunaFinder.Wildlife.Application.Client;
 
-public interface ISpeciesService
+public interface ISpeciesHttpClient
 {
     Task<IReadOnlyList<SpeciesForListDto>> GetSpeciesByMunicipalityAsync(
         int municipalityId,

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IWildlifeHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IWildlifeHttpClient.cs
@@ -2,7 +2,7 @@ using FaunaFinder.Wildlife.Contracts;
 
 namespace FaunaFinder.Wildlife.Application.Client;
 
-public interface IWildlifeService
+public interface IWildlifeHttpClient
 {
     Task<IReadOnlyList<SpeciesSearchResult>> SearchSpeciesAsync(
         string query,

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/MunicipalityHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/MunicipalityHttpClient.cs
@@ -5,68 +5,55 @@ using FaunaFinder.Pagination.Contracts;
 
 namespace FaunaFinder.Wildlife.Application.Client;
 
-public sealed class SpeciesApiService : ISpeciesService
+public sealed class MunicipalityHttpClient : IMunicipalityHttpClient
 {
     private readonly HttpClient _httpClient;
 
-    public SpeciesApiService(HttpClient httpClient)
+    public MunicipalityHttpClient(HttpClient httpClient)
     {
         _httpClient = httpClient;
     }
 
-    public async Task<IReadOnlyList<SpeciesForListDto>> GetSpeciesByMunicipalityAsync(
+    public async Task<IReadOnlyList<MunicipalityForListDto>> GetAllMunicipalitiesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _httpClient.GetFromJsonAsync<IReadOnlyList<MunicipalityForListDto>>(
+            "api/municipalities",
+            cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<MunicipalityForDetailDto?> GetMunicipalityDetailAsync(
         int municipalityId,
         CancellationToken cancellationToken = default)
     {
-        var result = await _httpClient.GetFromJsonAsync<IReadOnlyList<SpeciesForListDto>>(
-            $"api/species/by-municipality/{municipalityId}",
+        return await _httpClient.GetFromJsonAsync<MunicipalityForDetailDto>(
+            $"api/municipalities/{municipalityId}",
+            cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<MunicipalityCardDto>> GetMunicipalitiesWithSpeciesCountAsync(
+        MunicipalityParameters parameters,
+        CancellationToken cancellationToken = default)
+    {
+        var queryString = BuildMunicipalityQueryString(parameters);
+        var result = await _httpClient.GetFromJsonAsync<IReadOnlyList<MunicipalityCardDto>>(
+            $"api/municipalities/cards{queryString}",
             cancellationToken);
         return result ?? [];
     }
 
-    public async Task<SpeciesForDetailDto?> GetSpeciesDetailAsync(
-        int speciesId,
-        CancellationToken cancellationToken = default)
-    {
-        return await _httpClient.GetFromJsonAsync<SpeciesForDetailDto>(
-            $"api/species/{speciesId}",
-            cancellationToken);
-    }
-
-    public async Task<IReadOnlyList<SpeciesForSearchDto>> GetSpeciesAsync(
-        SpeciesParameters parameters,
-        CancellationToken cancellationToken = default)
-    {
-        var queryString = BuildSpeciesQueryString(parameters);
-        var result = await _httpClient.GetFromJsonAsync<IReadOnlyList<SpeciesForSearchDto>>(
-            $"api/species{queryString}",
-            cancellationToken);
-        return result ?? [];
-    }
-
-    public async Task<int> GetTotalSpeciesCountAsync(
+    public async Task<int> GetTotalMunicipalitiesCountAsync(
         string? search = null,
         CancellationToken cancellationToken = default)
     {
         var queryString = string.IsNullOrEmpty(search) ? "" : $"?search={Uri.EscapeDataString(search)}";
         return await _httpClient.GetFromJsonAsync<int>(
-            $"api/species/count{queryString}",
+            $"api/municipalities/count{queryString}",
             cancellationToken);
     }
 
-    public async Task<IReadOnlyList<SpeciesNearbyDto>> GetSpeciesNearbyAsync(
-        double latitude,
-        double longitude,
-        double radiusMeters,
-        CancellationToken cancellationToken = default)
-    {
-        var result = await _httpClient.GetFromJsonAsync<IReadOnlyList<SpeciesNearbyDto>>(
-            $"api/species/nearby?latitude={latitude}&longitude={longitude}&radiusMeters={radiusMeters}",
-            cancellationToken);
-        return result ?? [];
-    }
-
-    private static string BuildSpeciesQueryString(SpeciesParameters parameters)
+    private static string BuildMunicipalityQueryString(MunicipalityParameters parameters)
     {
         var queryParams = new List<string>
         {
@@ -79,23 +66,18 @@ public sealed class SpeciesApiService : ISpeciesService
             queryParams.Add($"search={Uri.EscapeDataString(parameters.Search)}");
         }
 
-        if (parameters.MunicipalityId.HasValue)
-        {
-            queryParams.Add($"municipalityId={parameters.MunicipalityId.Value}");
-        }
-
         return "?" + string.Join("&", queryParams);
     }
 
-    public async Task<CursorPage<SpeciesForSearchDto>> GetSpeciesCursorPageAsync(
+    public async Task<CursorPage<MunicipalityCardDto>> GetMunicipalitiesCursorPageAsync(
         CursorPageRequest request,
         CancellationToken cancellationToken = default)
     {
         var queryString = BuildCursorQueryString(request);
-        var result = await _httpClient.GetFromJsonAsync<CursorPage<SpeciesForSearchDto>>(
-            $"api/species/cursor{queryString}",
+        var result = await _httpClient.GetFromJsonAsync<CursorPage<MunicipalityCardDto>>(
+            $"api/municipalities/cursor{queryString}",
             cancellationToken);
-        return result ?? new CursorPage<SpeciesForSearchDto>([], null, false);
+        return result ?? new CursorPage<MunicipalityCardDto>([], null, false);
     }
 
     private static string BuildCursorQueryString(CursorPageRequest request)

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/WildlifeHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/WildlifeHttpClient.cs
@@ -3,11 +3,11 @@ using FaunaFinder.Wildlife.Contracts;
 
 namespace FaunaFinder.Wildlife.Application.Client;
 
-public sealed class WildlifeApiService : IWildlifeService
+public sealed class WildlifeHttpClient : IWildlifeHttpClient
 {
     private readonly HttpClient _httpClient;
 
-    public WildlifeApiService(HttpClient httpClient)
+    public WildlifeHttpClient(HttpClient httpClient)
     {
         _httpClient = httpClient;
     }


### PR DESCRIPTION
## Summary
Rename all HTTP client services in `.Application.Client` projects to use the `HttpClient` suffix for consistency and clarity.

Closes #141

## Changes

| Old Name | New Name |
|----------|----------|
| `IMunicipalityService` | `IMunicipalityHttpClient` |
| `MunicipalityApiService` | `MunicipalityHttpClient` |
| `ISpeciesService` | `ISpeciesHttpClient` |
| `SpeciesApiService` | `SpeciesHttpClient` |
| `IWildlifeService` | `IWildlifeHttpClient` |
| `WildlifeApiService` | `WildlifeHttpClient` |
| `IExportService` | `IExportHttpClient` |
| `ExportApiService` | `ExportHttpClient` |

- Updated DI registrations in `DependencyInjection.cs`
- Updated all Blazor page references

## Rationale
- Distinguishes HTTP client wrappers from server-side services
- Follows existing pattern: `IIdentityClient`/`IdentityClient`
- Makes it clear these are for Blazor WASM HTTP calls

## Test plan
- [x] Build succeeds
- [x] All pages load without DI errors
