### PR TITLE
Add Sighting Details page for students to view their reports

### DIFF
--- a/src/FaunaFinder.Client/Pages/Wildlife/MySightings.razor
+++ b/src/FaunaFinder.Client/Pages/Wildlife/MySightings.razor
@@ -146,7 +146,7 @@
 
     private void ViewSighting(int id)
     {
-        Navigation.NavigateTo($"/sightings/{id}");
+        Navigation.NavigateTo($"/my-sightings/{id}");
     }
 
     private Color GetStatusColor(string status) => status switch

--- a/src/FaunaFinder.Client/Pages/Wildlife/SightingDetail.razor
+++ b/src/FaunaFinder.Client/Pages/Wildlife/SightingDetail.razor
@@ -1,0 +1,359 @@
+@page "/my-sightings/{Id:int}"
+@using Microsoft.AspNetCore.Authorization
+@using FaunaFinder.Wildlife.Contracts.Dtos
+@inject IWildlifeHttpClient WildlifeHttpClient
+@inject NavigationManager Navigation
+@inject IJSRuntime JS
+@inject IAppLocalizer L
+@attribute [Authorize]
+
+<PageTitle>@L["SightingDetail_Title"] - FaunaFinder</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+    @* Back Navigation *@
+    <MudButton Variant="Variant.Text"
+               Color="Color.Primary"
+               StartIcon="@Icons.Material.Filled.ArrowBack"
+               OnClick="NavigateBack"
+               Class="mb-4">
+        @L["Back"]
+    </MudButton>
+
+    @if (_isLoading)
+    {
+        <MudPaper Elevation="2" Class="pa-4 mb-4">
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="40px" Class="mb-3 rounded" />
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="24px" Width="60%" Class="mb-3 rounded" />
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="200px" Class="mb-3 rounded" />
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="100px" Class="rounded" />
+        </MudPaper>
+    }
+    else if (_error is not null)
+    {
+        <MudAlert Severity="Severity.Error" Class="mb-4">@_error</MudAlert>
+    }
+    else if (_sighting is null)
+    {
+        <MudAlert Severity="Severity.Warning" Class="mb-4">@L["SightingDetail_NotFound"]</MudAlert>
+    }
+    else
+    {
+        @* Species Header *@
+        <MudPaper Elevation="2" Class="pa-4 mb-4">
+            <div class="d-flex justify-space-between align-start flex-wrap gap-2">
+                <div>
+                    <MudText Typo="Typo.h4" Color="Color.Primary" GutterBottom="true">
+                        @(_sighting.SpeciesName ?? L["Sightings_UnknownSpecies"])
+                    </MudText>
+                    @if (!string.IsNullOrEmpty(_sighting.SpeciesScientificName))
+                    {
+                        <MudText Typo="Typo.h6" Color="Color.Secondary" Class="font-italic">
+                            @_sighting.SpeciesScientificName
+                        </MudText>
+                    }
+                </div>
+                <MudChip T="string" Size="Size.Medium" Color="@GetStatusColor(_sighting.Status)" Variant="Variant.Filled">
+                    @GetStatusText(_sighting.Status)
+                </MudChip>
+            </div>
+        </MudPaper>
+
+        <MudGrid Spacing="4">
+            @* Left Column - Photo and Map *@
+            <MudItem xs="12" md="6">
+                @* Photo *@
+                <MudPaper Elevation="2" Class="pa-4 mb-4">
+                    <MudText Typo="Typo.h6" Class="mb-3">@L["SightingDetail_Photo"]</MudText>
+                    @if (_sighting.HasPhoto)
+                    {
+                        <MudImage Src="@($"api/wildlife/sightings/{_sighting.Id}/photo")"
+                                  Alt="@L["SightingDetail_PhotoAlt"]"
+                                  ObjectFit="ObjectFit.Cover"
+                                  Class="rounded-lg"
+                                  Style="width: 100%; max-height: 400px;" />
+                    }
+                    else
+                    {
+                        <div class="d-flex justify-center align-center rounded-lg"
+                             style="height: 200px; background-color: var(--mud-palette-background-grey);">
+                            <MudStack AlignItems="AlignItems.Center">
+                                <MudIcon Icon="@Icons.Material.Filled.HideImage" Size="Size.Large" Color="Color.Secondary" />
+                                <MudText Color="Color.Secondary">@L["SightingDetail_NoPhoto"]</MudText>
+                            </MudStack>
+                        </div>
+                    }
+                </MudPaper>
+
+                @* Location Map *@
+                <MudPaper Elevation="2" Class="pa-4">
+                    <MudText Typo="Typo.h6" Class="mb-3">@L["SightingDetail_Location"]</MudText>
+                    <div id="sighting-map" class="rounded-lg" style="height: 300px; width: 100%;"></div>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-2">
+                        @_sighting.Latitude.ToString("F6"), @_sighting.Longitude.ToString("F6")
+                    </MudText>
+                </MudPaper>
+            </MudItem>
+
+            @* Right Column - Details *@
+            <MudItem xs="12" md="6">
+                @* Observation Details *@
+                <MudPaper Elevation="2" Class="pa-4 mb-4">
+                    <MudText Typo="Typo.h6" Class="mb-3">@L["SightingDetail_ObservationDetails"]</MudText>
+
+                    <MudGrid Spacing="2">
+                        <MudItem xs="6">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["SightingDetail_ObservedAt"]</MudText>
+                            <MudText Typo="Typo.body1">@_sighting.ObservedAt.ToLocalTime().ToString("g")</MudText>
+                        </MudItem>
+                        <MudItem xs="6">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["SightingDetail_ReportedAt"]</MudText>
+                            <MudText Typo="Typo.body1">@_sighting.CreatedAt.ToLocalTime().ToString("g")</MudText>
+                        </MudItem>
+                        <MudItem xs="6">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Sighting_Mode"]</MudText>
+                            <MudText Typo="Typo.body1">@GetModeText(_sighting.Mode)</MudText>
+                        </MudItem>
+                        <MudItem xs="6">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Sighting_Confidence"]</MudText>
+                            <MudText Typo="Typo.body1">@GetConfidenceText(_sighting.Confidence)</MudText>
+                        </MudItem>
+                        <MudItem xs="6">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Sighting_Count"]</MudText>
+                            <MudText Typo="Typo.body1">@GetCountText(_sighting.Count)</MudText>
+                        </MudItem>
+                        @if (!string.IsNullOrEmpty(_sighting.Weather))
+                        {
+                            <MudItem xs="6">
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["SightingDetail_Weather"]</MudText>
+                                <MudText Typo="Typo.body1">@GetWeatherText(_sighting.Weather)</MudText>
+                            </MudItem>
+                        }
+                    </MudGrid>
+
+                    @* Behaviors *@
+                    @if (_sighting.Behaviors > 0)
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-3 mb-1">@L["Sighting_Behavior"]</MudText>
+                        <div class="d-flex flex-wrap gap-1">
+                            @foreach (var behavior in GetBehaviors(_sighting.Behaviors))
+                            {
+                                <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">@behavior</MudChip>
+                            }
+                        </div>
+                    }
+
+                    @* Evidence *@
+                    @if (_sighting.Evidence > 0)
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-3 mb-1">@L["Sighting_Evidence"]</MudText>
+                        <div class="d-flex flex-wrap gap-1">
+                            @foreach (var evidence in GetEvidence(_sighting.Evidence))
+                            {
+                                <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Outlined">@evidence</MudChip>
+                            }
+                        </div>
+                    }
+                </MudPaper>
+
+                @* Notes *@
+                @if (!string.IsNullOrEmpty(_sighting.Notes))
+                {
+                    <MudPaper Elevation="2" Class="pa-4 mb-4">
+                        <MudText Typo="Typo.h6" Class="mb-2">@L["SightingDetail_Notes"]</MudText>
+                        <MudText Typo="Typo.body1" Style="white-space: pre-wrap;">@_sighting.Notes</MudText>
+                    </MudPaper>
+                }
+
+                @* Review Information *@
+                <MudPaper Elevation="2" Class="pa-4">
+                    <MudText Typo="Typo.h6" Class="mb-3">@L["SightingDetail_ReviewStatus"]</MudText>
+
+                    <div class="d-flex align-center gap-2 mb-3">
+                        <MudIcon Icon="@GetStatusIcon(_sighting.Status)" Color="@GetStatusColor(_sighting.Status)" />
+                        <MudText Typo="Typo.body1" Color="@GetStatusColor(_sighting.Status)">
+                            @GetStatusText(_sighting.Status)
+                        </MudText>
+                    </div>
+
+                    @if (_sighting.IsFlaggedForReview)
+                    {
+                        <MudAlert Severity="Severity.Info" Variant="Variant.Text" Dense="true" Class="mb-2">
+                            @L["SightingDetail_FlaggedForReview"]
+                        </MudAlert>
+                    }
+
+                    @if (_sighting.IsNewMunicipalityRecord)
+                    {
+                        <MudAlert Severity="Severity.Success" Variant="Variant.Text" Dense="true" Class="mb-2">
+                            @L["SightingDetail_NewMunicipalityRecord"]
+                        </MudAlert>
+                    }
+
+                    @if (_sighting.ReviewedAt.HasValue)
+                    {
+                        <MudDivider Class="my-3" />
+                        <MudGrid Spacing="2">
+                            <MudItem xs="12">
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["SightingDetail_ReviewedAt"]</MudText>
+                                <MudText Typo="Typo.body1">@_sighting.ReviewedAt.Value.ToLocalTime().ToString("g")</MudText>
+                            </MudItem>
+                            @if (!string.IsNullOrEmpty(_sighting.ReviewNotes))
+                            {
+                                <MudItem xs="12">
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@L["SightingDetail_ReviewNotes"]</MudText>
+                                    <MudText Typo="Typo.body1" Style="white-space: pre-wrap;">@_sighting.ReviewNotes</MudText>
+                                </MudItem>
+                            }
+                        </MudGrid>
+                    }
+                    else if (_sighting.Status == "Pending")
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">
+                            @L["SightingDetail_PendingReviewMessage"]
+                        </MudText>
+                    }
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+    }
+</MudContainer>
+
+@code {
+    [Parameter]
+    public int Id { get; set; }
+
+    private SightingDetailDto? _sighting;
+    private bool _isLoading = true;
+    private string? _error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadSighting();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && _sighting is not null)
+        {
+            await InitializeMap();
+        }
+    }
+
+    private async Task LoadSighting()
+    {
+        _isLoading = true;
+        _error = null;
+
+        try
+        {
+            _sighting = await WildlifeHttpClient.GetSightingDetailAsync(Id);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+        {
+            _error = L["Sightings_Unauthorized"];
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _sighting = null;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task InitializeMap()
+    {
+        if (_sighting is null) return;
+
+        await JS.InvokeVoidAsync("initSightingMap",
+            "sighting-map",
+            _sighting.Latitude,
+            _sighting.Longitude);
+    }
+
+    private void NavigateBack()
+    {
+        Navigation.NavigateTo("/sightings");
+    }
+
+    private Color GetStatusColor(string status) => status switch
+    {
+        "Approved" => Color.Success,
+        "Rejected" => Color.Error,
+        "Pending" => Color.Warning,
+        _ => Color.Default
+    };
+
+    private string GetStatusIcon(string status) => status switch
+    {
+        "Approved" => Icons.Material.Filled.CheckCircle,
+        "Rejected" => Icons.Material.Filled.Cancel,
+        "Pending" => Icons.Material.Filled.Schedule,
+        _ => Icons.Material.Filled.HelpOutline
+    };
+
+    private string GetStatusText(string status) => status switch
+    {
+        "Approved" => L["Sightings_StatusApproved"],
+        "Rejected" => L["Sightings_StatusRejected"],
+        "Pending" => L["Sightings_StatusPending"],
+        _ => status
+    };
+
+    private string GetModeText(string mode) => mode switch
+    {
+        "Casual" => L["Sighting_ModeCasual"],
+        "Survey" => L["Sighting_ModeSurvey"],
+        _ => mode
+    };
+
+    private string GetConfidenceText(string confidence) => confidence switch
+    {
+        "Certain" => L["Sighting_ConfidenceCertain"],
+        "FairlySure" => L["Sighting_ConfidenceFairlySure"],
+        "Unsure" => L["Sighting_ConfidenceUnsure"],
+        _ => confidence
+    };
+
+    private string GetCountText(string count) => count switch
+    {
+        "One" => "1",
+        "TwoToFive" => "2-5",
+        "SixToTwenty" => "6-20",
+        "TwentyPlus" => "20+",
+        _ => count
+    };
+
+    private string GetWeatherText(string weather) => weather switch
+    {
+        "Clear" => L["Sighting_WeatherClear"],
+        "PartlyCloudy" => L["Sighting_WeatherPartlyCloudy"],
+        "Cloudy" => L["Sighting_WeatherCloudy"],
+        "Rainy" => L["Sighting_WeatherRainy"],
+        "Stormy" => L["Sighting_WeatherStormy"],
+        "Foggy" => L["Sighting_WeatherFoggy"],
+        "Windy" => L["Sighting_WeatherWindy"],
+        _ => weather
+    };
+
+    private IEnumerable<string> GetBehaviors(int behaviors)
+    {
+        if ((behaviors & 1) != 0) yield return L["Sighting_BehaviorFeeding"];
+        if ((behaviors & 2) != 0) yield return L["Sighting_BehaviorResting"];
+        if ((behaviors & 4) != 0) yield return L["Sighting_BehaviorMoving"];
+        if ((behaviors & 8) != 0) yield return L["Sighting_BehaviorCalling"];
+    }
+
+    private IEnumerable<string> GetEvidence(int evidence)
+    {
+        if ((evidence & 1) != 0) yield return L["Sighting_EvidenceVisual"];
+        if ((evidence & 2) != 0) yield return L["Sighting_EvidenceHeard"];
+        if ((evidence & 4) != 0) yield return L["Sighting_EvidenceTracks"];
+        if ((evidence & 8) != 0) yield return L["Sighting_EvidencePhoto"];
+    }
+}

--- a/src/FaunaFinder.Client/Services/Localization/Translations.cs
+++ b/src/FaunaFinder.Client/Services/Localization/Translations.cs
@@ -244,6 +244,25 @@ public static class Translations
         ["Sightings_StatusApproved"] = "Approved",
         ["Sightings_StatusRejected"] = "Rejected",
         ["Sightings_StatusPending"] = "Pending",
+
+        // Sighting Detail
+        ["SightingDetail_Title"] = "Sighting Details",
+        ["SightingDetail_NotFound"] = "Sighting not found.",
+        ["SightingDetail_Photo"] = "Photo",
+        ["SightingDetail_PhotoAlt"] = "Sighting photo",
+        ["SightingDetail_NoPhoto"] = "No photo available",
+        ["SightingDetail_Location"] = "Location",
+        ["SightingDetail_ObservationDetails"] = "Observation Details",
+        ["SightingDetail_ObservedAt"] = "Observed",
+        ["SightingDetail_ReportedAt"] = "Reported",
+        ["SightingDetail_Weather"] = "Weather",
+        ["SightingDetail_Notes"] = "Notes",
+        ["SightingDetail_ReviewStatus"] = "Review Status",
+        ["SightingDetail_ReviewedAt"] = "Reviewed",
+        ["SightingDetail_ReviewNotes"] = "Review Notes",
+        ["SightingDetail_FlaggedForReview"] = "This sighting has been flagged for expert review.",
+        ["SightingDetail_NewMunicipalityRecord"] = "This is a new species record for this municipality!",
+        ["SightingDetail_PendingReviewMessage"] = "Your sighting is awaiting review by a teacher or administrator.",
     };
 
     public static IReadOnlyDictionary<string, string> Spanish { get; } = new Dictionary<string, string>
@@ -488,5 +507,24 @@ public static class Translations
         ["Sightings_StatusApproved"] = "Aprobado",
         ["Sightings_StatusRejected"] = "Rechazado",
         ["Sightings_StatusPending"] = "Pendiente",
+
+        // Sighting Detail
+        ["SightingDetail_Title"] = "Detalles del Avistamiento",
+        ["SightingDetail_NotFound"] = "Avistamiento no encontrado.",
+        ["SightingDetail_Photo"] = "Foto",
+        ["SightingDetail_PhotoAlt"] = "Foto del avistamiento",
+        ["SightingDetail_NoPhoto"] = "No hay foto disponible",
+        ["SightingDetail_Location"] = "Ubicación",
+        ["SightingDetail_ObservationDetails"] = "Detalles de la Observación",
+        ["SightingDetail_ObservedAt"] = "Observado",
+        ["SightingDetail_ReportedAt"] = "Reportado",
+        ["SightingDetail_Weather"] = "Clima",
+        ["SightingDetail_Notes"] = "Notas",
+        ["SightingDetail_ReviewStatus"] = "Estado de Revisión",
+        ["SightingDetail_ReviewedAt"] = "Revisado",
+        ["SightingDetail_ReviewNotes"] = "Notas de Revisión",
+        ["SightingDetail_FlaggedForReview"] = "Este avistamiento ha sido marcado para revisión de expertos.",
+        ["SightingDetail_NewMunicipalityRecord"] = "¡Este es un nuevo registro de especie para este municipio!",
+        ["SightingDetail_PendingReviewMessage"] = "Tu avistamiento está esperando revisión por un maestro o administrador.",
     };
 }

--- a/src/FaunaFinder.Server/wwwroot/js/leafletInterop.ts
+++ b/src/FaunaFinder.Server/wwwroot/js/leafletInterop.ts
@@ -110,6 +110,7 @@ type LocateControlState = 'loading' | 'default';
 interface Window {
     leafletInterop: LeafletInterop;
     downloadFile: (base64: string, fileName: string, contentType: string) => void;
+    initSightingMap: (containerId: string, latitude: number, longitude: number) => void;
 }
 
 // Extend Leaflet types for GeoJSON layer with feature property
@@ -827,3 +828,70 @@ function downloadFile(base64: string, fileName: string, contentType: string): vo
 }
 
 window.downloadFile = downloadFile;
+
+// ============================================================================
+// Sighting Detail Map Function
+// ============================================================================
+
+/**
+ * Initialize a simple map for sighting detail view with a marker at the given location
+ */
+function initSightingMap(containerId: string, latitude: number, longitude: number): void {
+    const container = document.getElementById(containerId);
+    if (!container) {
+        console.error('Map container not found:', containerId);
+        return;
+    }
+
+    // Check if map already exists on this container
+    if ((container as any)._leaflet_id) {
+        return;
+    }
+
+    const savedDarkMode = localStorage.getItem('faunafinder-darkmode');
+    const isDarkMode = savedDarkMode !== null
+        ? savedDarkMode === 'true'
+        : window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    const tileUrl = isDarkMode
+        ? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
+        : 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+
+    const attribution = isDarkMode
+        ? '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+        : '&copy; OpenStreetMap';
+
+    const map = L.map(containerId, {
+        center: [latitude, longitude],
+        zoom: 14,
+        scrollWheelZoom: false,
+        dragging: true,
+        zoomControl: true
+    });
+
+    L.tileLayer(tileUrl, {
+        attribution: attribution,
+        maxZoom: 18
+    }).addTo(map);
+
+    // Add a marker at the sighting location
+    const markerIcon = L.divIcon({
+        className: 'sighting-location-marker',
+        html: '<div style="background-color: #ef4444; width: 16px; height: 16px; border-radius: 50%; border: 3px solid #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.3);"></div>',
+        iconSize: [22, 22],
+        iconAnchor: [11, 11]
+    });
+
+    L.marker([latitude, longitude], { icon: markerIcon }).addTo(map);
+
+    // Add a subtle circle around the marker
+    L.circle([latitude, longitude], {
+        radius: 50,
+        fillColor: '#ef4444',
+        color: '#dc2626',
+        weight: 2,
+        fillOpacity: 0.2
+    }).addTo(map);
+}
+
+window.initSightingMap = initSightingMap;

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IWildlifeHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IWildlifeHttpClient.cs
@@ -1,4 +1,5 @@
 using FaunaFinder.Wildlife.Contracts;
+using FaunaFinder.Wildlife.Contracts.Dtos;
 
 namespace FaunaFinder.Wildlife.Application.Client;
 
@@ -27,5 +28,9 @@ public interface IWildlifeHttpClient
 
     Task<CreateSightingResponse> CreateSightingAsync(
         CreateSightingRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<SightingDetailDto?> GetSightingDetailAsync(
+        int id,
         CancellationToken cancellationToken = default);
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/WildlifeHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/WildlifeHttpClient.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using FaunaFinder.Wildlife.Contracts;
+using FaunaFinder.Wildlife.Contracts.Dtos;
 
 namespace FaunaFinder.Wildlife.Application.Client;
 
@@ -75,6 +76,14 @@ public sealed class WildlifeHttpClient : IWildlifeHttpClient
 
         var error = await response.Content.ReadAsStringAsync(cancellationToken);
         return new CreateSightingResponse(null, error, false);
+    }
+
+    public async Task<SightingDetailDto?> GetSightingDetailAsync(
+        int id,
+        CancellationToken cancellationToken = default)
+    {
+        var url = $"/api/wildlife/sightings/{id}";
+        return await _httpClient.GetFromJsonAsync<SightingDetailDto>(url, cancellationToken);
     }
 
     private record IdResponse(int Id);


### PR DESCRIPTION
## Summary
Students can now view full details of their wildlife sighting reports by clicking on a sighting in the MySightings list.

Closes #145

## Changes

### New Page: `SightingDetail.razor`
- Route: `/my-sightings/{id}`
- Displays all sighting information:
  - Species name and scientific name
  - Photo (or placeholder if none)
  - Location on Leaflet map
  - Observation details (date, mode, confidence, count, weather)
  - Behaviors and evidence as chips
  - Notes
  - Review status with color-coded badges (Pending/Approved/Rejected)
  - Review notes and date (if reviewed)

### HTTP Client Updates
- Added `GetSightingDetailAsync(int id)` to `IWildlifeHttpClient`
- Implemented in `WildlifeHttpClient` using existing `/api/wildlife/sightings/{id}` endpoint

### Navigation
- Updated `MySightings.razor` to navigate to `/my-sightings/{id}` on row click

### Localization
- Added 17 new translation keys for English and Spanish

### JavaScript
- Added `initSightingMap()` function to `leafletInterop.ts`

## Test plan
- [ ] Navigate to MySightings, click on a sighting
- [ ] Verify all details display correctly
- [ ] Verify photo displays (or placeholder)
- [ ] Verify map shows location
- [ ] Verify review status shows with correct color
- [ ] Test back navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)