### PR TITLE
Fix navigation after creating sighting

### DIFF
--- a/src/FaunaFinder.Client/Pages/Wildlife/ReportSighting.razor
+++ b/src/FaunaFinder.Client/Pages/Wildlife/ReportSighting.razor
@@ -274,7 +274,7 @@
 
             if (result.Success && result.Id.HasValue)
             {
-                Navigation.NavigateTo($"/sightings/{result.Id}");
+                Navigation.NavigateTo($"/my-sightings/{result.Id}");
             }
             else
             {


### PR DESCRIPTION
## Summary
- Fix navigation URL after creating a sighting to go to the detail page

## Changes
- Changed navigation from `/sightings/{id}` to `/my-sightings/{id}` in ReportSighting.razor

Closes #151