### PR TITLE
Configure seeder to publish as Azure Container App Job

### DIFF
--- a/src/FaunaFinder.AppHost/FaunaFinder.AppHost.csproj
+++ b/src/FaunaFinder.AppHost/FaunaFinder.AppHost.csproj
@@ -6,9 +6,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>faunafinder-apphost</UserSecretsId>
+    <NoWarn>$(NoWarn);ASPIREAZURE002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.Azure.AppContainers" Version="13.1.0" />
     <PackageReference Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.1.0" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.1.0" />
   </ItemGroup>

--- a/src/FaunaFinder.AppHost/Program.cs
+++ b/src/FaunaFinder.AppHost/Program.cs
@@ -1,3 +1,5 @@
+using Azure.Provisioning.AppContainers;
+
 var builder = DistributedApplication.CreateBuilder(args);
 
 // PostgreSQL database server
@@ -26,7 +28,16 @@ var seeder = builder.AddProject<Projects.FaunaFinder_Seeder>("seeder")
     .WithReference(wildlifeDb)
     .WaitFor(mainDb)
     .WaitFor(identityDb)
-    .WaitFor(wildlifeDb);
+    .WaitFor(wildlifeDb)
+    .PublishAsAzureContainerAppJob((infra, job) =>
+    {
+        job.Configuration = new ContainerAppJobConfiguration
+        {
+            TriggerType = ContainerAppJobTriggerType.Manual,
+            ReplicaTimeout = 1800, // 30 min max runtime
+            ReplicaRetryLimit = 0  // no retries
+        };
+    });
 
 // API + WASM Client
 builder.AddProject<Projects.FaunaFinder_Server>("server")


### PR DESCRIPTION
## Summary
- Configure the database seeder to deploy as an Azure Container App Job instead of a long-running service
- Add manual trigger with 30-minute timeout and no retries
- Suppress ASPIREAZURE002 experimental API diagnostic to allow build

## Test plan
- [ ] Verify solution builds without errors
- [ ] Verify seeder still runs correctly in local development
- [ ] Verify Azure deployment creates job resource correctly