### PR TITLE
Remove first-user-becomes-admin bootstrap logic

### DIFF
--- a/src/Features/Identity/FaunaFinder.Identity.Application/Services/AuthService.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application/Services/AuthService.cs
@@ -22,15 +22,13 @@ public sealed class AuthService(
             return new EmailAlreadyExistsError(request.Email);
         }
 
-        var isFirstUser = !userManager.Users.Any();
-
         var user = new User
         {
             UserName = request.Email,
             Email = request.Email,
             DisplayName = request.DisplayName,
-            Status = isFirstUser ? UserStatus.Approved : UserStatus.Pending,
-            Role = isFirstUser ? UserRole.Admin : UserRole.Viewer,
+            Status = UserStatus.Pending,
+            Role = UserRole.Viewer,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow
         };


### PR DESCRIPTION
## Summary
- Removed the first-user-becomes-admin logic from `AuthService.RegisterAsync` — all users now register with `Viewer` role and `Pending` status

## Test plan
- [ ] Register a new user and verify they get `Viewer` role and `Pending` status (not Admin, even if they are the first user)

Closes #157