### PR TITLE
Add cursor-based access request pagination and dedicated page (#165)

### DIFF
--- a/src/FaunaFinder.Client/Pages/Admin/AccessRequestDetails.razor
+++ b/src/FaunaFinder.Client/Pages/Admin/AccessRequestDetails.razor
@@ -1,4 +1,4 @@
-@page "/dashboard/access-requests/{Id:int}"
+@page "/admin/access-requests/{Id:int}"
 @using Microsoft.AspNetCore.Authorization
 @using FaunaFinder.Identity.Application.Client
 @using FaunaFinder.Identity.Contracts.Requests
@@ -15,7 +15,7 @@
     <MudButton Variant="Variant.Text"
                Color="Color.Primary"
                StartIcon="@Icons.Material.Filled.ArrowBack"
-               OnClick="@(() => Navigation.NavigateTo("/dashboard"))"
+               OnClick="@(() => Navigation.NavigateTo("/admin/access-requests"))"
                Class="mb-4">
         @L["Back"]
     </MudButton>

--- a/src/FaunaFinder.Client/Pages/Admin/AccessRequests.razor
+++ b/src/FaunaFinder.Client/Pages/Admin/AccessRequests.razor
@@ -1,0 +1,262 @@
+@page "/admin/access-requests"
+@using Microsoft.AspNetCore.Authorization
+@using FaunaFinder.Identity.Application.Client
+@using FaunaFinder.Identity.Contracts.Requests
+@using FaunaFinder.Identity.Contracts.Responses
+@inject IIdentityClient IdentityClient
+@inject IAppLocalizer L
+@inject NavigationManager Navigation
+@inject IJSRuntime JS
+@implements IDisposable
+@attribute [Authorize(Roles = "Admin")]
+
+<PageTitle>@L["Admin_AccessRequests_Title"] - FaunaFinder</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+    <MudButton Variant="Variant.Text"
+               Color="Color.Primary"
+               StartIcon="@Icons.Material.Filled.ArrowBack"
+               OnClick="@(() => Navigation.NavigateTo("/dashboard"))"
+               Class="mb-4">
+        @L["Back"]
+    </MudButton>
+
+    <MudText Typo="Typo.h4" Class="mb-2">@L["Admin_AccessRequests_Title"]</MudText>
+    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">@L["Admin_AccessRequests_Description"]</MudText>
+
+    <MudGrid Class="mb-4">
+        <MudItem xs="12" sm="8" md="9">
+            <MudTextField T="string"
+                          Value="_searchText"
+                          ValueChanged="OnSearchChanged"
+                          Placeholder="@L["Admin_AccessRequests_SearchPlaceholder"]"
+                          Variant="Variant.Outlined"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Search"
+                          DebounceInterval="300"
+                          Immediate="true" />
+        </MudItem>
+        <MudItem xs="12" sm="4" md="3">
+            <MudSelect T="string"
+                       Value="_statusFilter"
+                       ValueChanged="OnStatusFilterChanged"
+                       Variant="Variant.Outlined">
+                <MudSelectItem T="string" Value="@("Pending")">@L["Admin_Pending"]</MudSelectItem>
+                <MudSelectItem T="string" Value="@("Approved")">@L["Admin_Approved"]</MudSelectItem>
+                <MudSelectItem T="string" Value="@("Rejected")">@L["Admin_Rejected"]</MudSelectItem>
+                <MudSelectItem T="string" Value="@("")">@L["Admin_AccessRequests_StatusAll"]</MudSelectItem>
+            </MudSelect>
+        </MudItem>
+    </MudGrid>
+
+    @if (_isInitialLoading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+    }
+    else if (_error is not null)
+    {
+        <MudAlert Severity="Severity.Error" Class="mb-4">@_error</MudAlert>
+    }
+    else if (_requests.Count == 0)
+    {
+        <MudPaper Class="pa-6 text-center" Elevation="0">
+            <MudIcon Icon="@Icons.Material.Filled.HowToReg" Size="Size.Large" Color="Color.Secondary" Class="mb-4" />
+            <MudText Typo="Typo.h6" Color="Color.Secondary">@L["Admin_NoAccessRequests"]</MudText>
+        </MudPaper>
+    }
+    else
+    {
+        <MudTable Items="_requests" Dense="true" Hover="true" Striped="true" Elevation="2">
+            <HeaderContent>
+                <MudTh>@L["Admin_DisplayName"]</MudTh>
+                <MudTh>@L["Admin_Email"]</MudTh>
+                <MudTh>@L["Admin_Message"]</MudTh>
+                <MudTh>@L["Admin_Status"]</MudTh>
+                <MudTh>@L["Admin_CreatedAt"]</MudTh>
+                <MudTh>@L["Admin_Actions"]</MudTh>
+            </HeaderContent>
+            <RowTemplate Context="request">
+                <MudTd DataLabel="@L["Admin_DisplayName"]">@request.DisplayName</MudTd>
+                <MudTd DataLabel="@L["Admin_Email"]">@request.Email</MudTd>
+                <MudTd DataLabel="@L["Admin_Message"]">
+                    @(request.Message is not null && request.Message.Length > 50
+                        ? request.Message[..50] + "..."
+                        : request.Message ?? "-")
+                </MudTd>
+                <MudTd DataLabel="@L["Admin_Status"]">
+                    <MudChip T="string"
+                             Size="Size.Small"
+                             Color="@GetStatusColor(request.Status)">
+                        @GetStatusText(request.Status)
+                    </MudChip>
+                </MudTd>
+                <MudTd DataLabel="@L["Admin_CreatedAt"]">@request.CreatedAt.ToLocalTime().ToString("g")</MudTd>
+                <MudTd DataLabel="@L["Admin_Actions"]">
+                    <MudButton Variant="Variant.Outlined"
+                               Size="Size.Small"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.Info"
+                               OnClick="@(() => Navigation.NavigateTo($"/admin/access-requests/{request.Id}"))">
+                        @L["Admin_ViewDetails"]
+                    </MudButton>
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+
+        @if (_isLoadingMore)
+        {
+            <div class="d-flex justify-center mt-4">
+                <MudProgressCircular Indeterminate="true" Color="Color.Primary" />
+            </div>
+        }
+
+        @if (_hasMore)
+        {
+            <div @ref="_sentinel" style="height: 1px;"></div>
+        }
+    }
+</MudContainer>
+
+@code {
+    private readonly List<AccessRequestInfo> _requests = new();
+    private string? _nextCursor;
+    private bool _hasMore;
+    private bool _isInitialLoading = true;
+    private bool _isLoadingMore;
+    private string? _error;
+    private string _searchText = string.Empty;
+    private string _statusFilter = "Pending";
+
+    private ElementReference _sentinel;
+    private DotNetObjectReference<AccessRequests>? _dotNetRef;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _dotNetRef = DotNetObjectReference.Create(this);
+        await LoadPageAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender && _hasMore && !_isLoadingMore && !_isInitialLoading)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("infiniteScrollInterop.observe", _sentinel, _dotNetRef);
+            }
+            catch (JSException)
+            {
+                // Element may not be in DOM yet
+            }
+        }
+    }
+
+    [JSInvokable]
+    public async Task LoadMore()
+    {
+        if (_isLoadingMore || !_hasMore) return;
+        await LoadPageAsync();
+        StateHasChanged();
+    }
+
+    private async Task LoadPageAsync()
+    {
+        if (_isLoadingMore) return;
+
+        var isFirstPage = _nextCursor is null && _requests.Count == 0;
+        if (isFirstPage)
+            _isInitialLoading = true;
+        else
+            _isLoadingMore = true;
+
+        _error = null;
+
+        try
+        {
+            var status = string.IsNullOrEmpty(_statusFilter) ? null : _statusFilter;
+            var search = string.IsNullOrWhiteSpace(_searchText) ? null : _searchText;
+            var request = new AccessRequestPageRequest(_nextCursor, 20, search, status);
+            var result = await IdentityClient.GetAccessRequestsCursorPageAsync(request);
+
+            result.Switch(
+                page =>
+                {
+                    _requests.AddRange(page.Items);
+                    _nextCursor = page.NextCursor;
+                    _hasMore = page.HasMore;
+                },
+                forbidden => _error = L["Admin_AccessDeniedMessage"],
+                unexpected => _error = unexpected.Message
+            );
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _isInitialLoading = false;
+            _isLoadingMore = false;
+        }
+    }
+
+    private async Task OnSearchChanged(string value)
+    {
+        _searchText = value;
+        await ResetAndReload();
+    }
+
+    private async Task OnStatusFilterChanged(string value)
+    {
+        _statusFilter = value;
+        await ResetAndReload();
+    }
+
+    private async Task ResetAndReload()
+    {
+        _requests.Clear();
+        _nextCursor = null;
+        _hasMore = false;
+
+        try
+        {
+            await JS.InvokeVoidAsync("infiniteScrollInterop.disconnect");
+        }
+        catch (JSException)
+        {
+            // Interop may not be initialized
+        }
+
+        await LoadPageAsync();
+    }
+
+    private Color GetStatusColor(string status) => status switch
+    {
+        "Pending" => Color.Warning,
+        "Approved" => Color.Success,
+        "Rejected" => Color.Error,
+        _ => Color.Default
+    };
+
+    private string GetStatusText(string status) => status switch
+    {
+        "Pending" => L["Admin_Pending"],
+        "Approved" => L["Admin_Approved"],
+        "Rejected" => L["Admin_Rejected"],
+        _ => status
+    };
+
+    public void Dispose()
+    {
+        try
+        {
+            JS.InvokeVoidAsync("infiniteScrollInterop.disconnect");
+        }
+        catch
+        {
+            // Ignore disposal errors
+        }
+
+        _dotNetRef?.Dispose();
+    }
+}

--- a/src/FaunaFinder.Client/Services/Localization/Translations.cs
+++ b/src/FaunaFinder.Client/Services/Localization/Translations.cs
@@ -192,6 +192,11 @@ public static class Translations
         ["Admin_AccessRequestDetails"] = "Access Request Details",
         ["Admin_Message"] = "Message",
         ["Admin_NoAccessRequests"] = "No pending access requests.",
+        ["Admin_AccessRequests_Title"] = "Access Requests",
+        ["Admin_AccessRequests_Description"] = "Review and manage user registration requests.",
+        ["Admin_AccessRequests_SearchPlaceholder"] = "Search by name or email...",
+        ["Admin_AccessRequests_StatusFilter"] = "Status",
+        ["Admin_AccessRequests_StatusAll"] = "All",
         ["Nav_Admin"] = "Admin",
 
         // User Menu
@@ -511,6 +516,11 @@ public static class Translations
         ["Admin_AccessRequestDetails"] = "Detalles de Solicitud",
         ["Admin_Message"] = "Mensaje",
         ["Admin_NoAccessRequests"] = "No hay solicitudes de acceso pendientes.",
+        ["Admin_AccessRequests_Title"] = "Solicitudes de Acceso",
+        ["Admin_AccessRequests_Description"] = "Revisar y gestionar solicitudes de registro de usuarios.",
+        ["Admin_AccessRequests_SearchPlaceholder"] = "Buscar por nombre o correo...",
+        ["Admin_AccessRequests_StatusFilter"] = "Estado",
+        ["Admin_AccessRequests_StatusAll"] = "Todos",
         ["Nav_Admin"] = "Admin",
 
         // User Menu

--- a/src/Features/Identity/FaunaFinder.Identity.Api/AuthEndpoints.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Api/AuthEndpoints.cs
@@ -29,6 +29,8 @@ public static class AuthEndpoints
 
         group.MapGet("/access-requests/pending", GetPendingAccessRequests)
             .RequireAuthorization(policy => policy.RequireRole("Admin"));
+        group.MapGet("/access-requests/search", GetAccessRequestsCursorPage)
+            .RequireAuthorization(policy => policy.RequireRole("Admin"));
         group.MapPut("/access-requests/{id}/status", UpdateAccessRequestStatus)
             .RequireAuthorization(policy => policy.RequireRole("Admin"));
 
@@ -134,6 +136,24 @@ public static class AuthEndpoints
     {
         var request = new CursorPageRequest(cursor, pageSize ?? 20, search);
         var result = await authService.GetUsersCursorPageAsync(request, cancellationToken);
+
+        return result.Match<IResult>(
+            page => Results.Ok(page),
+            forbidden => Results.Forbid(),
+            unexpected => Results.Problem(unexpected.Message, statusCode: StatusCodes.Status500InternalServerError)
+        );
+    }
+
+    private static async Task<IResult> GetAccessRequestsCursorPage(
+        string? cursor,
+        int? pageSize,
+        string? search,
+        string? status,
+        IAuthService authService,
+        CancellationToken cancellationToken)
+    {
+        var request = new AccessRequestPageRequest(cursor, pageSize ?? 20, search, status);
+        var result = await authService.GetAccessRequestsCursorPageAsync(request, cancellationToken);
 
         return result.Match<IResult>(
             page => Results.Ok(page),

--- a/src/Features/Identity/FaunaFinder.Identity.Application.Client/IIdentityClient.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application.Client/IIdentityClient.cs
@@ -13,5 +13,6 @@ public interface IIdentityClient
     Task<GetUsersResult> GetAllUsersAsync(CancellationToken cancellationToken = default);
     Task<GetUsersCursorPageResult> GetUsersCursorPageAsync(CursorPageRequest request, CancellationToken cancellationToken = default);
     Task<GetAccessRequestsResult> GetPendingAccessRequestsAsync(CancellationToken cancellationToken = default);
+    Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default);
     Task<UpdateAccessRequestStatusResult> UpdateAccessRequestStatusAsync(int id, UpdateAccessRequestStatusRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/Features/Identity/FaunaFinder.Identity.Application.Client/IdentityClient.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application.Client/IdentityClient.cs
@@ -150,6 +150,34 @@ public sealed class IdentityClient : IIdentityClient
         return new UnexpectedError(await response.Content.ReadAsStringAsync(cancellationToken));
     }
 
+    public async Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default)
+    {
+        var queryParams = new List<string> { $"pageSize={request.PageSize}" };
+
+        if (!string.IsNullOrEmpty(request.Cursor))
+            queryParams.Add($"cursor={Uri.EscapeDataString(request.Cursor)}");
+
+        if (!string.IsNullOrEmpty(request.Search))
+            queryParams.Add($"search={Uri.EscapeDataString(request.Search)}");
+
+        if (!string.IsNullOrEmpty(request.Status))
+            queryParams.Add($"status={Uri.EscapeDataString(request.Status)}");
+
+        var url = $"api/auth/access-requests/search?{string.Join("&", queryParams)}";
+        var response = await _httpClient.GetAsync(url, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var page = await response.Content.ReadFromJsonAsync<CursorPage<AccessRequestInfo>>(cancellationToken);
+            return page!;
+        }
+
+        if (response.StatusCode == HttpStatusCode.Forbidden)
+            return new ForbiddenError();
+
+        return new UnexpectedError(await response.Content.ReadAsStringAsync(cancellationToken));
+    }
+
     public async Task<GetAccessRequestsResult> GetPendingAccessRequestsAsync(CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.GetAsync("api/auth/access-requests/pending", cancellationToken);

--- a/src/Features/Identity/FaunaFinder.Identity.Application/Services/AuthService.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application/Services/AuthService.cs
@@ -135,6 +135,15 @@ public sealed class AuthService(
         return requests.ToArray();
     }
 
+    public async Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default)
+    {
+        if (!await IsCurrentUserAdminAsync())
+            return new ForbiddenError();
+
+        var page = await accessRequestRepository.GetCursorPageAsync(request, cancellationToken);
+        return page;
+    }
+
     public async Task<UpdateAccessRequestStatusResult> UpdateAccessRequestStatusAsync(int id, UpdateAccessRequestStatusRequest request, CancellationToken cancellationToken = default)
     {
         if (!await IsCurrentUserAdminAsync())

--- a/src/Features/Identity/FaunaFinder.Identity.Application/Services/IAuthService.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application/Services/IAuthService.cs
@@ -13,5 +13,6 @@ public interface IAuthService
     Task<GetUsersResult> GetAllUsersAsync(CancellationToken cancellationToken = default);
     Task<GetUsersCursorPageResult> GetUsersCursorPageAsync(CursorPageRequest request, CancellationToken cancellationToken = default);
     Task<GetAccessRequestsResult> GetPendingAccessRequestsAsync(CancellationToken cancellationToken = default);
+    Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default);
     Task<UpdateAccessRequestStatusResult> UpdateAccessRequestStatusAsync(int id, UpdateAccessRequestStatusRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/Features/Identity/FaunaFinder.Identity.Contracts/Requests/AccessRequestPageRequest.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Contracts/Requests/AccessRequestPageRequest.cs
@@ -1,0 +1,8 @@
+namespace FaunaFinder.Identity.Contracts.Requests;
+
+public record AccessRequestPageRequest(
+    string? Cursor,
+    int PageSize = 20,
+    string? Search = null,
+    string? Status = null
+);

--- a/src/Features/Identity/FaunaFinder.Identity.Contracts/Results/AuthResult.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Contracts/Results/AuthResult.cs
@@ -27,3 +27,6 @@ public partial class UpdateAccessRequestStatusResult : OneOfBase<AccessRequestIn
 
 [GenerateOneOf]
 public partial class GetUsersCursorPageResult : OneOfBase<CursorPage<UserInfo>, ForbiddenError, UnexpectedError>;
+
+[GenerateOneOf]
+public partial class GetAccessRequestsCursorPageResult : OneOfBase<CursorPage<AccessRequestInfo>, ForbiddenError, UnexpectedError>;

--- a/src/Features/Identity/FaunaFinder.Identity.DataAccess/Interfaces/IAccessRequestRepository.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.DataAccess/Interfaces/IAccessRequestRepository.cs
@@ -1,5 +1,7 @@
+using FaunaFinder.Identity.Contracts.Requests;
 using FaunaFinder.Identity.Contracts.Responses;
 using FaunaFinder.Identity.Database.Models;
+using FaunaFinder.Pagination.Contracts;
 
 namespace FaunaFinder.Identity.DataAccess.Interfaces;
 
@@ -10,4 +12,5 @@ public interface IAccessRequestRepository
     Task<AccessRequest?> GetEntityByEmailAsync(string email, CancellationToken cancellationToken = default);
     Task<AccessRequestInfo> CreateAsync(AccessRequest accessRequest, CancellationToken cancellationToken = default);
     Task<AccessRequestInfo?> UpdateStatusAsync(int id, AccessRequestStatus status, CancellationToken cancellationToken = default);
+    Task<CursorPage<AccessRequestInfo>> GetCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/Features/Identity/FaunaFinder.Identity.DataAccess/Repositories/AccessRequestRepository.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.DataAccess/Repositories/AccessRequestRepository.cs
@@ -1,7 +1,9 @@
+using FaunaFinder.Identity.Contracts.Requests;
 using FaunaFinder.Identity.Contracts.Responses;
 using FaunaFinder.Identity.Database;
 using FaunaFinder.Identity.Database.Models;
 using FaunaFinder.Identity.DataAccess.Interfaces;
+using FaunaFinder.Pagination.Contracts;
 using Microsoft.EntityFrameworkCore;
 
 namespace FaunaFinder.Identity.DataAccess.Repositories;
@@ -92,5 +94,55 @@ public sealed class AccessRequestRepository(
             request.Message,
             request.Status.ToString(),
             request.CreatedAt);
+    }
+
+    public async Task<CursorPage<AccessRequestInfo>> GetCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var query = context.AccessRequests.AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(request.Status) &&
+            Enum.TryParse<AccessRequestStatus>(request.Status, out var statusFilter))
+        {
+            query = query.Where(r => r.Status == statusFilter);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Search))
+        {
+            var search = request.Search.ToLower();
+            query = query.Where(r =>
+                r.Email.ToLower().Contains(search) ||
+                r.DisplayName.ToLower().Contains(search));
+        }
+
+        if (request.Cursor is not null && CursorHelper.TryDecode(request.Cursor, out var cursorId))
+        {
+            query = query.Where(r => r.Id > cursorId);
+        }
+
+        var items = await query
+            .OrderBy(r => r.Id)
+            .Take(request.PageSize + 1)
+            .Select(r => new AccessRequestInfo(
+                r.Id,
+                r.Email,
+                r.DisplayName,
+                r.Message,
+                r.Status.ToString(),
+                r.CreatedAt))
+            .ToListAsync(cancellationToken);
+
+        var hasMore = items.Count > request.PageSize;
+        if (hasMore)
+        {
+            items.RemoveAt(items.Count - 1);
+        }
+
+        var nextCursor = hasMore && items.Count > 0
+            ? CursorHelper.Encode(items[^1].Id)
+            : null;
+
+        return new CursorPage<AccessRequestInfo>(items, nextCursor, hasMore);
     }
 }


### PR DESCRIPTION
## Summary
- Add `GET /access-requests/search` endpoint with cursor-based pagination, search, and status filter (Pending/Approved/Rejected/All)
- Create dedicated `/admin/access-requests` page with infinite scroll, debounced search bar, and responsive status dropdown using `MudGrid`
- Update `AccessRequestDetails` route from `/dashboard/access-requests/{id}` to `/admin/access-requests/{id}` with back nav to the new list page

## Test plan
- [ ] Navigate to `/admin/access-requests` — loads first page filtered by Pending
- [ ] Type in search bar — filters by name/email with debounce
- [ ] Switch status dropdown between Pending/Approved/Rejected/All
- [ ] Scroll down to trigger infinite scroll for next page
- [ ] Click "View Details" — navigates to `/admin/access-requests/{id}`
- [ ] Back button on details page returns to `/admin/access-requests`
- [ ] Verify responsive layout: status dropdown stacks below search on mobile

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)