### PR TITLE
Fix AccessRequestDetails to load any request by ID

### DIFF
--- a/src/FaunaFinder.Client/Pages/Admin/AccessRequestDetails.razor
+++ b/src/FaunaFinder.Client/Pages/Admin/AccessRequestDetails.razor
@@ -146,14 +146,10 @@
 
         try
         {
-            var result = await IdentityClient.GetPendingAccessRequestsAsync();
+            var result = await IdentityClient.GetAccessRequestByIdAsync(Id);
             result.Switch(
-                requests =>
-                {
-                    _request = requests.FirstOrDefault(r => r.Id == Id);
-                    if (_request is null)
-                        _error = L["Admin_UserNotFound"];
-                },
+                accessRequest => _request = accessRequest,
+                notFound => _error = L["Admin_UserNotFound"],
                 forbidden => _error = L["Admin_AccessDeniedMessage"],
                 unexpected => _error = unexpected.Message
             );

--- a/src/Features/Identity/FaunaFinder.Identity.Api/AuthEndpoints.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Api/AuthEndpoints.cs
@@ -31,6 +31,8 @@ public static class AuthEndpoints
             .RequireAuthorization(policy => policy.RequireRole("Admin"));
         group.MapGet("/access-requests/search", GetAccessRequestsCursorPage)
             .RequireAuthorization(policy => policy.RequireRole("Admin"));
+        group.MapGet("/access-requests/{id}", GetAccessRequestById)
+            .RequireAuthorization(policy => policy.RequireRole("Admin"));
         group.MapPut("/access-requests/{id}/status", UpdateAccessRequestStatus)
             .RequireAuthorization(policy => policy.RequireRole("Admin"));
 
@@ -122,6 +124,21 @@ public static class AuthEndpoints
 
         return result.Match<IResult>(
             requests => Results.Ok(requests),
+            forbidden => Results.Forbid(),
+            unexpected => Results.Problem(unexpected.Message, statusCode: StatusCodes.Status500InternalServerError)
+        );
+    }
+
+    private static async Task<IResult> GetAccessRequestById(
+        int id,
+        IAuthService authService,
+        CancellationToken cancellationToken)
+    {
+        var result = await authService.GetAccessRequestByIdAsync(id, cancellationToken);
+
+        return result.Match<IResult>(
+            accessRequest => Results.Ok(accessRequest),
+            notFound => Results.NotFound(notFound),
             forbidden => Results.Forbid(),
             unexpected => Results.Problem(unexpected.Message, statusCode: StatusCodes.Status500InternalServerError)
         );

--- a/src/Features/Identity/FaunaFinder.Identity.Application.Client/IIdentityClient.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application.Client/IIdentityClient.cs
@@ -13,6 +13,7 @@ public interface IIdentityClient
     Task<GetUsersResult> GetAllUsersAsync(CancellationToken cancellationToken = default);
     Task<GetUsersCursorPageResult> GetUsersCursorPageAsync(CursorPageRequest request, CancellationToken cancellationToken = default);
     Task<GetAccessRequestsResult> GetPendingAccessRequestsAsync(CancellationToken cancellationToken = default);
+    Task<GetAccessRequestByIdResult> GetAccessRequestByIdAsync(int id, CancellationToken cancellationToken = default);
     Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default);
     Task<UpdateAccessRequestStatusResult> UpdateAccessRequestStatusAsync(int id, UpdateAccessRequestStatusRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/Features/Identity/FaunaFinder.Identity.Application.Client/IdentityClient.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application.Client/IdentityClient.cs
@@ -178,6 +178,24 @@ public sealed class IdentityClient : IIdentityClient
         return new UnexpectedError(await response.Content.ReadAsStringAsync(cancellationToken));
     }
 
+    public async Task<GetAccessRequestByIdResult> GetAccessRequestByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync($"api/auth/access-requests/{id}", cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var accessRequest = await response.Content.ReadFromJsonAsync<AccessRequestInfo>(cancellationToken);
+            return accessRequest!;
+        }
+
+        return response.StatusCode switch
+        {
+            HttpStatusCode.NotFound => new AccessRequestNotFoundError(id),
+            HttpStatusCode.Forbidden => new ForbiddenError(),
+            _ => new UnexpectedError(await response.Content.ReadAsStringAsync(cancellationToken))
+        };
+    }
+
     public async Task<GetAccessRequestsResult> GetPendingAccessRequestsAsync(CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.GetAsync("api/auth/access-requests/pending", cancellationToken);

--- a/src/Features/Identity/FaunaFinder.Identity.Application/Services/AuthService.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application/Services/AuthService.cs
@@ -135,6 +135,18 @@ public sealed class AuthService(
         return requests.ToArray();
     }
 
+    public async Task<GetAccessRequestByIdResult> GetAccessRequestByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        if (!await IsCurrentUserAdminAsync())
+            return new ForbiddenError();
+
+        var accessRequest = await accessRequestRepository.GetByIdAsync(id, cancellationToken);
+        if (accessRequest is null)
+            return new AccessRequestNotFoundError(id);
+
+        return accessRequest;
+    }
+
     public async Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default)
     {
         if (!await IsCurrentUserAdminAsync())

--- a/src/Features/Identity/FaunaFinder.Identity.Application/Services/IAuthService.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application/Services/IAuthService.cs
@@ -13,6 +13,7 @@ public interface IAuthService
     Task<GetUsersResult> GetAllUsersAsync(CancellationToken cancellationToken = default);
     Task<GetUsersCursorPageResult> GetUsersCursorPageAsync(CursorPageRequest request, CancellationToken cancellationToken = default);
     Task<GetAccessRequestsResult> GetPendingAccessRequestsAsync(CancellationToken cancellationToken = default);
+    Task<GetAccessRequestByIdResult> GetAccessRequestByIdAsync(int id, CancellationToken cancellationToken = default);
     Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default);
     Task<UpdateAccessRequestStatusResult> UpdateAccessRequestStatusAsync(int id, UpdateAccessRequestStatusRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/Features/Identity/FaunaFinder.Identity.Contracts/Results/AuthResult.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Contracts/Results/AuthResult.cs
@@ -29,4 +29,7 @@ public partial class UpdateAccessRequestStatusResult : OneOfBase<AccessRequestIn
 public partial class GetUsersCursorPageResult : OneOfBase<CursorPage<UserInfo>, ForbiddenError, UnexpectedError>;
 
 [GenerateOneOf]
+public partial class GetAccessRequestByIdResult : OneOfBase<AccessRequestInfo, AccessRequestNotFoundError, ForbiddenError, UnexpectedError>;
+
+[GenerateOneOf]
 public partial class GetAccessRequestsCursorPageResult : OneOfBase<CursorPage<AccessRequestInfo>, ForbiddenError, UnexpectedError>;


### PR DESCRIPTION
## Summary
- Add dedicated `GET /access-requests/{id}` endpoint that returns a single access request regardless of status
- Update `AccessRequestDetails.razor` to call the new endpoint instead of fetching all pending requests and filtering client-side

## Test plan
- [ ] Navigate to `/admin/access-requests/{id}` for a Pending request — loads correctly
- [ ] Navigate to `/admin/access-requests/{id}` for an Approved request — loads correctly
- [ ] Navigate to `/admin/access-requests/{id}` for a Rejected request — loads correctly
- [ ] Navigate to `/admin/access-requests/999999` (non-existent) — shows not found error

Fixes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)