### PR TITLE
Rename PageRequest types to PageParameter (#166)

### DIFF
--- a/src/Common/FaunaFinder.Pagination.Contracts/CursorPageParameter.cs
+++ b/src/Common/FaunaFinder.Pagination.Contracts/CursorPageParameter.cs
@@ -1,6 +1,6 @@
 namespace FaunaFinder.Pagination.Contracts;
 
-public record CursorPageRequest(
+public record CursorPageParameter(
     string? Cursor,
     int PageSize = 20,
     string? Search = null

--- a/src/FaunaFinder.Client/Pages/Admin/AccessRequests.razor
+++ b/src/FaunaFinder.Client/Pages/Admin/AccessRequests.razor
@@ -175,7 +175,7 @@
         {
             var status = string.IsNullOrEmpty(_statusFilter) ? null : _statusFilter;
             var search = string.IsNullOrWhiteSpace(_searchText) ? null : _searchText;
-            var request = new AccessRequestPageRequest(_nextCursor, 20, search, status);
+            var request = new AccessRequestPageParameter(_nextCursor, 20, search, status);
             var result = await IdentityClient.GetAccessRequestsCursorPageAsync(request);
 
             result.Switch(

--- a/src/FaunaFinder.Client/Pages/Admin/Users.razor
+++ b/src/FaunaFinder.Client/Pages/Admin/Users.razor
@@ -151,7 +151,7 @@
 
         try
         {
-            var request = new CursorPageRequest(_nextCursor, 20, string.IsNullOrWhiteSpace(_searchText) ? null : _searchText);
+            var request = new CursorPageParameter(_nextCursor, 20, string.IsNullOrWhiteSpace(_searchText) ? null : _searchText);
             var result = await IdentityClient.GetUsersCursorPageAsync(request);
 
             result.Switch(

--- a/src/FaunaFinder.Client/Pages/Pueblos.razor
+++ b/src/FaunaFinder.Client/Pages/Pueblos.razor
@@ -119,7 +119,7 @@
         isLoadingMore = true;
         StateHasChanged();
 
-        var request = new CursorPageRequest(nextCursor, PageSize, string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm);
+        var request = new CursorPageParameter(nextCursor, PageSize, string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm);
         var page = await MunicipalityHttpClient.GetMunicipalitiesCursorPageAsync(request);
 
         municipalities.AddRange(page.Items);

--- a/src/FaunaFinder.Client/Pages/Species.razor
+++ b/src/FaunaFinder.Client/Pages/Species.razor
@@ -123,7 +123,7 @@
         isLoadingMore = true;
         StateHasChanged();
 
-        var request = new CursorPageRequest(nextCursor, PageSize, string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm);
+        var request = new CursorPageParameter(nextCursor, PageSize, string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm);
         var page = await SpeciesHttpClient.GetSpeciesCursorPageAsync(request);
 
         species.AddRange(page.Items);

--- a/src/FaunaFinder.Server/Endpoints/MunicipalityEndpoints.cs
+++ b/src/FaunaFinder.Server/Endpoints/MunicipalityEndpoints.cs
@@ -83,7 +83,7 @@ public static class MunicipalityEndpoints
             IMunicipalityRepository repository,
             CancellationToken ct) =>
         {
-            var request = new CursorPageRequest(cursor, pageSize, search);
+            var request = new CursorPageParameter(cursor, pageSize, search);
             var page = await repository.GetMunicipalitiesCursorPageAsync(request, ct);
             return Results.Ok(page);
         }).WithName("GetMunicipalitiesCursor");

--- a/src/FaunaFinder.Server/Endpoints/SpeciesEndpoints.cs
+++ b/src/FaunaFinder.Server/Endpoints/SpeciesEndpoints.cs
@@ -63,7 +63,7 @@ public static class SpeciesEndpoints
             ISpeciesRepository repository,
             CancellationToken ct) =>
         {
-            var request = new CursorPageRequest(cursor, pageSize, search);
+            var request = new CursorPageParameter(cursor, pageSize, search);
             var page = await repository.GetSpeciesCursorPageAsync(request, ct);
             return Results.Ok(page);
         }).WithName("GetSpeciesCursor");

--- a/src/Features/Identity/FaunaFinder.Identity.Api/AuthEndpoints.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Api/AuthEndpoints.cs
@@ -151,7 +151,7 @@ public static class AuthEndpoints
         IAuthService authService,
         CancellationToken cancellationToken)
     {
-        var request = new CursorPageRequest(cursor, pageSize ?? 20, search);
+        var request = new CursorPageParameter(cursor, pageSize ?? 20, search);
         var result = await authService.GetUsersCursorPageAsync(request, cancellationToken);
 
         return result.Match<IResult>(
@@ -169,7 +169,7 @@ public static class AuthEndpoints
         IAuthService authService,
         CancellationToken cancellationToken)
     {
-        var request = new AccessRequestPageRequest(cursor, pageSize ?? 20, search, status);
+        var request = new AccessRequestPageParameter(cursor, pageSize ?? 20, search, status);
         var result = await authService.GetAccessRequestsCursorPageAsync(request, cancellationToken);
 
         return result.Match<IResult>(

--- a/src/Features/Identity/FaunaFinder.Identity.Application.Client/IIdentityClient.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application.Client/IIdentityClient.cs
@@ -11,9 +11,9 @@ public interface IIdentityClient
     Task LogoutAsync(CancellationToken cancellationToken = default);
     Task<GetCurrentUserResult> GetCurrentUserAsync(CancellationToken cancellationToken = default);
     Task<GetUsersResult> GetAllUsersAsync(CancellationToken cancellationToken = default);
-    Task<GetUsersCursorPageResult> GetUsersCursorPageAsync(CursorPageRequest request, CancellationToken cancellationToken = default);
+    Task<GetUsersCursorPageResult> GetUsersCursorPageAsync(CursorPageParameter request, CancellationToken cancellationToken = default);
     Task<GetAccessRequestsResult> GetPendingAccessRequestsAsync(CancellationToken cancellationToken = default);
     Task<GetAccessRequestByIdResult> GetAccessRequestByIdAsync(int id, CancellationToken cancellationToken = default);
-    Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default);
+    Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageParameter request, CancellationToken cancellationToken = default);
     Task<UpdateAccessRequestStatusResult> UpdateAccessRequestStatusAsync(int id, UpdateAccessRequestStatusRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/Features/Identity/FaunaFinder.Identity.Application.Client/IdentityClient.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application.Client/IdentityClient.cs
@@ -125,7 +125,7 @@ public sealed class IdentityClient : IIdentityClient
         return new UnexpectedError(await response.Content.ReadAsStringAsync(cancellationToken));
     }
 
-    public async Task<GetUsersCursorPageResult> GetUsersCursorPageAsync(CursorPageRequest request, CancellationToken cancellationToken = default)
+    public async Task<GetUsersCursorPageResult> GetUsersCursorPageAsync(CursorPageParameter request, CancellationToken cancellationToken = default)
     {
         var queryParams = new List<string> { $"pageSize={request.PageSize}" };
 
@@ -150,7 +150,7 @@ public sealed class IdentityClient : IIdentityClient
         return new UnexpectedError(await response.Content.ReadAsStringAsync(cancellationToken));
     }
 
-    public async Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default)
+    public async Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageParameter request, CancellationToken cancellationToken = default)
     {
         var queryParams = new List<string> { $"pageSize={request.PageSize}" };
 

--- a/src/Features/Identity/FaunaFinder.Identity.Application/Services/AuthService.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application/Services/AuthService.cs
@@ -117,7 +117,7 @@ public sealed class AuthService(
         return users.ToArray();
     }
 
-    public async Task<GetUsersCursorPageResult> GetUsersCursorPageAsync(CursorPageRequest request, CancellationToken cancellationToken = default)
+    public async Task<GetUsersCursorPageResult> GetUsersCursorPageAsync(CursorPageParameter request, CancellationToken cancellationToken = default)
     {
         if (!await IsCurrentUserAdminAsync())
             return new ForbiddenError();
@@ -147,7 +147,7 @@ public sealed class AuthService(
         return accessRequest;
     }
 
-    public async Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default)
+    public async Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageParameter request, CancellationToken cancellationToken = default)
     {
         if (!await IsCurrentUserAdminAsync())
             return new ForbiddenError();

--- a/src/Features/Identity/FaunaFinder.Identity.Application/Services/IAuthService.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Application/Services/IAuthService.cs
@@ -11,9 +11,9 @@ public interface IAuthService
     Task LogoutAsync(CancellationToken cancellationToken = default);
     Task<GetCurrentUserResult> GetCurrentUserAsync(CancellationToken cancellationToken = default);
     Task<GetUsersResult> GetAllUsersAsync(CancellationToken cancellationToken = default);
-    Task<GetUsersCursorPageResult> GetUsersCursorPageAsync(CursorPageRequest request, CancellationToken cancellationToken = default);
+    Task<GetUsersCursorPageResult> GetUsersCursorPageAsync(CursorPageParameter request, CancellationToken cancellationToken = default);
     Task<GetAccessRequestsResult> GetPendingAccessRequestsAsync(CancellationToken cancellationToken = default);
     Task<GetAccessRequestByIdResult> GetAccessRequestByIdAsync(int id, CancellationToken cancellationToken = default);
-    Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default);
+    Task<GetAccessRequestsCursorPageResult> GetAccessRequestsCursorPageAsync(AccessRequestPageParameter request, CancellationToken cancellationToken = default);
     Task<UpdateAccessRequestStatusResult> UpdateAccessRequestStatusAsync(int id, UpdateAccessRequestStatusRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/Features/Identity/FaunaFinder.Identity.Contracts/Requests/AccessRequestPageParameter.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.Contracts/Requests/AccessRequestPageParameter.cs
@@ -1,6 +1,6 @@
 namespace FaunaFinder.Identity.Contracts.Requests;
 
-public record AccessRequestPageRequest(
+public record AccessRequestPageParameter(
     string? Cursor,
     int PageSize = 20,
     string? Search = null,

--- a/src/Features/Identity/FaunaFinder.Identity.DataAccess/Interfaces/IAccessRequestRepository.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.DataAccess/Interfaces/IAccessRequestRepository.cs
@@ -12,5 +12,5 @@ public interface IAccessRequestRepository
     Task<AccessRequest?> GetEntityByEmailAsync(string email, CancellationToken cancellationToken = default);
     Task<AccessRequestInfo> CreateAsync(AccessRequest accessRequest, CancellationToken cancellationToken = default);
     Task<AccessRequestInfo?> UpdateStatusAsync(int id, AccessRequestStatus status, CancellationToken cancellationToken = default);
-    Task<CursorPage<AccessRequestInfo>> GetCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default);
+    Task<CursorPage<AccessRequestInfo>> GetCursorPageAsync(AccessRequestPageParameter request, CancellationToken cancellationToken = default);
 }

--- a/src/Features/Identity/FaunaFinder.Identity.DataAccess/Interfaces/IUserRepository.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.DataAccess/Interfaces/IUserRepository.cs
@@ -8,5 +8,5 @@ public interface IUserRepository
     Task<UserInfo?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
     Task<UserInfo?> GetByEmailAsync(string email, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<UserInfo>> GetAllAsync(CancellationToken cancellationToken = default);
-    Task<CursorPage<UserInfo>> GetCursorPageAsync(CursorPageRequest request, CancellationToken cancellationToken = default);
+    Task<CursorPage<UserInfo>> GetCursorPageAsync(CursorPageParameter request, CancellationToken cancellationToken = default);
 }

--- a/src/Features/Identity/FaunaFinder.Identity.DataAccess/Repositories/AccessRequestRepository.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.DataAccess/Repositories/AccessRequestRepository.cs
@@ -96,7 +96,7 @@ public sealed class AccessRequestRepository(
             request.CreatedAt);
     }
 
-    public async Task<CursorPage<AccessRequestInfo>> GetCursorPageAsync(AccessRequestPageRequest request, CancellationToken cancellationToken = default)
+    public async Task<CursorPage<AccessRequestInfo>> GetCursorPageAsync(AccessRequestPageParameter request, CancellationToken cancellationToken = default)
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
 

--- a/src/Features/Identity/FaunaFinder.Identity.DataAccess/Repositories/UserRepository.cs
+++ b/src/Features/Identity/FaunaFinder.Identity.DataAccess/Repositories/UserRepository.cs
@@ -58,7 +58,7 @@ public sealed class UserRepository(
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<CursorPage<UserInfo>> GetCursorPageAsync(CursorPageRequest request, CancellationToken cancellationToken = default)
+    public async Task<CursorPage<UserInfo>> GetCursorPageAsync(CursorPageParameter request, CancellationToken cancellationToken = default)
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
 

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IMunicipalityHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IMunicipalityHttpClient.cs
@@ -22,6 +22,6 @@ public interface IMunicipalityHttpClient
         CancellationToken cancellationToken = default);
 
     Task<CursorPage<MunicipalityCardDto>> GetMunicipalitiesCursorPageAsync(
-        CursorPageRequest request,
+        CursorPageParameter request,
         CancellationToken cancellationToken = default);
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/ISpeciesHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/ISpeciesHttpClient.cs
@@ -29,6 +29,6 @@ public interface ISpeciesHttpClient
         CancellationToken cancellationToken = default);
 
     Task<CursorPage<SpeciesForSearchDto>> GetSpeciesCursorPageAsync(
-        CursorPageRequest request,
+        CursorPageParameter request,
         CancellationToken cancellationToken = default);
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/MunicipalityHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/MunicipalityHttpClient.cs
@@ -70,7 +70,7 @@ public sealed class MunicipalityHttpClient : IMunicipalityHttpClient
     }
 
     public async Task<CursorPage<MunicipalityCardDto>> GetMunicipalitiesCursorPageAsync(
-        CursorPageRequest request,
+        CursorPageParameter request,
         CancellationToken cancellationToken = default)
     {
         var queryString = BuildCursorQueryString(request);
@@ -80,7 +80,7 @@ public sealed class MunicipalityHttpClient : IMunicipalityHttpClient
         return result ?? new CursorPage<MunicipalityCardDto>([], null, false);
     }
 
-    private static string BuildCursorQueryString(CursorPageRequest request)
+    private static string BuildCursorQueryString(CursorPageParameter request)
     {
         var queryParams = new List<string>
         {

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/SpeciesHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/SpeciesHttpClient.cs
@@ -88,7 +88,7 @@ public sealed class SpeciesHttpClient : ISpeciesHttpClient
     }
 
     public async Task<CursorPage<SpeciesForSearchDto>> GetSpeciesCursorPageAsync(
-        CursorPageRequest request,
+        CursorPageParameter request,
         CancellationToken cancellationToken = default)
     {
         var queryString = BuildCursorQueryString(request);
@@ -98,7 +98,7 @@ public sealed class SpeciesHttpClient : ISpeciesHttpClient
         return result ?? new CursorPage<SpeciesForSearchDto>([], null, false);
     }
 
-    private static string BuildCursorQueryString(CursorPageRequest request)
+    private static string BuildCursorQueryString(CursorPageParameter request)
     {
         var queryParams = new List<string>
         {

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Interfaces/IMunicipalityRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Interfaces/IMunicipalityRepository.cs
@@ -22,6 +22,6 @@ public interface IMunicipalityRepository
         CancellationToken cancellationToken = default);
 
     Task<CursorPage<MunicipalityCardDto>> GetMunicipalitiesCursorPageAsync(
-        CursorPageRequest request,
+        CursorPageParameter request,
         CancellationToken cancellationToken = default);
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Interfaces/ISpeciesRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Interfaces/ISpeciesRepository.cs
@@ -41,6 +41,6 @@ public interface ISpeciesRepository
         CancellationToken cancellationToken = default);
 
     Task<CursorPage<SpeciesForSearchDto>> GetSpeciesCursorPageAsync(
-        CursorPageRequest request,
+        CursorPageParameter request,
         CancellationToken cancellationToken = default);
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/MunicipalityRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/MunicipalityRepository.cs
@@ -89,7 +89,7 @@ public sealed class MunicipalityRepository(
     }
 
     public async Task<CursorPage<MunicipalityCardDto>> GetMunicipalitiesCursorPageAsync(
-        CursorPageRequest request,
+        CursorPageParameter request,
         CancellationToken cancellationToken = default)
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
@@ -279,7 +279,7 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
     }
 
     public async Task<CursorPage<SpeciesForSearchDto>> GetSpeciesCursorPageAsync(
-        CursorPageRequest request,
+        CursorPageParameter request,
         CancellationToken cancellationToken = default)
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- Rename `CursorPageRequest` to `CursorPageParameter` (file + all 20 usages)
- Rename `AccessRequestPageRequest` to `AccessRequestPageParameter` (file + all 8 usages)
- These are query parameter containers, not HTTP request bodies, so "Parameter" is more accurate

## Test plan
- [ ] `dotnet build` passes with 0 errors
- [ ] Existing pagination functionality unchanged (species, municipalities, users, access requests)

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)