### PR TITLE
Add Azure Container App Environment for deployment

### DIFF
--- a/src/FaunaFinder.AppHost/Program.cs
+++ b/src/FaunaFinder.AppHost/Program.cs
@@ -2,6 +2,9 @@ using Azure.Provisioning.AppContainers;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+// Azure Container App Environment (required for publishing to Azure Container Apps)
+builder.AddAzureContainerAppEnvironment("aca");
+
 // PostgreSQL database server
 // - Uses container locally for development
 // - Uses Azure PostgreSQL Flexible Server when deployed to Azure


### PR DESCRIPTION
## Summary
- Adds `AddAzureContainerAppEnvironment("aca")` to the AppHost configuration
- Fixes deployment failure when using `azd` to deploy to Azure

## Problem
The `seeder` resource uses `PublishAsAzureContainerAppJob()` which requires an `AzureContainerAppEnvironmentResource` to be defined. Without it, the deployment fails during manifest generation with:

```
Resource 'seeder' is configured to publish as an Azure Container App,
but there are no 'AzureContainerAppEnvironmentResource' resources.
Ensure you have added one by calling 'AddAzureContainerAppEnvironment'.
```

## Test plan
- [ ] Verify `azd provision` succeeds
- [ ] Verify local development still works with `dotnet run`

