### PR TITLE
Fix: Close mobile sidebar on navigation

### DIFF
--- a/src/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/FaunaFinder.Client/Layout/MainLayout.razor
@@ -1,6 +1,7 @@
 @inherits LayoutComponentBase
 @inject IAppLocalizer L
 @inject IDarkModeService DarkModeService
+@inject NavigationManager NavigationManager
 @implements IDisposable
 
 <MudThemeProvider Theme="_theme" IsDarkMode="_isDarkMode" />
@@ -128,6 +129,7 @@
     protected override void OnInitialized()
     {
         DarkModeService.OnDarkModeChanged += OnDarkModeChanged;
+        NavigationManager.LocationChanged += OnLocationChanged;
         _isDarkMode = DarkModeService.IsDarkMode;
     }
 
@@ -135,6 +137,15 @@
     {
         _isDarkMode = DarkModeService.IsDarkMode;
         InvokeAsync(StateHasChanged);
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        if (_drawerOpen)
+        {
+            _drawerOpen = false;
+            InvokeAsync(StateHasChanged);
+        }
     }
 
     private void ToggleDrawer()
@@ -155,5 +166,6 @@
     public void Dispose()
     {
         DarkModeService.OnDarkModeChanged -= OnDarkModeChanged;
+        NavigationManager.LocationChanged -= OnLocationChanged;
     }
 }


### PR DESCRIPTION
## Summary

- Subscribes to `NavigationManager.LocationChanged` event to automatically close the drawer when navigation occurs
- Handles all navigation scenarios: nav link clicks, browser back/forward, and programmatic navigation
- Properly unsubscribes from the event on dispose to prevent memory leaks

## Test plan

- [ ] Open the app on a mobile device or with mobile viewport
- [ ] Open the sidebar menu
- [ ] Click on any navigation link
- [ ] Verify the sidebar closes automatically after navigation
- [ ] Test browser back/forward buttons with sidebar open

Closes #177