### PR TITLE
Refactor: Extract MapService and replace inline styles with CSS utility classes

### DIFF
--- a/src/FaunaFinder.Client/Components/MunicipalityCard.razor
+++ b/src/FaunaFinder.Client/Components/MunicipalityCard.razor
@@ -1,6 +1,6 @@
 @inject IAppLocalizer L
 
-<MudCard Elevation="2" Class="municipality-card" Style="cursor: pointer;" @onclick="OnClick">
+<MudCard Elevation="2" Class="municipality-card" @onclick="OnClick">
     <MudCardContent Class="@ContentClass">
         @if (Compact)
         {

--- a/src/FaunaFinder.Client/Components/SpeciesExpansionPanel.razor
+++ b/src/FaunaFinder.Client/Components/SpeciesExpansionPanel.razor
@@ -5,10 +5,10 @@
                    Class="mb-2">
     <TitleContent>
         <div class="d-flex flex-column">
-            <MudText Typo="@TitleTypo" Color="Color.Primary" Style="font-weight: 600;">
+            <MudText Typo="@TitleTypo" Color="Color.Primary" Class="font-semibold">
                 @L.GetLocalizedValue(Species.CommonName)
             </MudText>
-            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1" Style="font-style: italic;">
+            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1 italic">
                 @Species.ScientificName
             </MudText>
         </div>

--- a/src/FaunaFinder.Client/Components/SpeciesFilterToolbar.razor
+++ b/src/FaunaFinder.Client/Components/SpeciesFilterToolbar.razor
@@ -22,7 +22,7 @@
                        Margin="Margin.Dense"
                        Dense="true"
                        Clearable="true"
-                       Style="min-width: 150px;">
+                       Class="min-w-150">
                 @foreach (var practice in AvailableNrcsPractices)
                 {
                     <MudSelectItem Value="@practice">@practice</MudSelectItem>
@@ -36,7 +36,7 @@
                        Margin="Margin.Dense"
                        Dense="true"
                        Clearable="true"
-                       Style="min-width: 150px;">
+                       Class="min-w-150">
                 @foreach (var action in AvailableFwsActions)
                 {
                     <MudSelectItem Value="@action">@action</MudSelectItem>

--- a/src/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/FaunaFinder.Client/Layout/MainLayout.razor
@@ -75,7 +75,7 @@
                     @Body
                 </ChildContent>
             <ErrorContent Context="ex">
-                <MudContainer MaxWidth="MaxWidth.Small" Class="d-flex flex-column align-center justify-center" Style="height: calc(100vh - 64px);">
+                <MudContainer MaxWidth="MaxWidth.Small" Class="d-flex flex-column align-center justify-center h-full-minus-appbar">
                     <MudPaper Elevation="3" Class="pa-6 text-center">
                         <MudIcon Icon="@Icons.Material.Filled.Error" Color="Color.Error" Size="Size.Large" Class="mb-4" />
                         <MudText Typo="Typo.h5" Class="mb-2">@L["Error_SomethingWentWrong"]</MudText>

--- a/src/FaunaFinder.Client/Pages/Admin/AccessRequestDetails.razor
+++ b/src/FaunaFinder.Client/Pages/Admin/AccessRequestDetails.razor
@@ -60,7 +60,7 @@
                 <MudSimpleTable Dense="true" Hover="true">
                     <tbody>
                         <tr>
-                            <td style="width: 40%;"><strong>@L["Admin_DisplayName"]</strong></td>
+                            <td class="w-40-percent"><strong>@L["Admin_DisplayName"]</strong></td>
                             <td>@_request.DisplayName</td>
                         </tr>
                         <tr>

--- a/src/FaunaFinder.Client/Pages/Admin/AccessRequests.razor
+++ b/src/FaunaFinder.Client/Pages/Admin/AccessRequests.razor
@@ -112,7 +112,7 @@
 
         @if (_hasMore)
         {
-            <div @ref="_sentinel" style="height: 1px;"></div>
+            <div @ref="_sentinel" class="h-1"></div>
         }
     }
 </MudContainer>

--- a/src/FaunaFinder.Client/Pages/Admin/Dashboard.razor
+++ b/src/FaunaFinder.Client/Pages/Admin/Dashboard.razor
@@ -47,18 +47,18 @@
                         }
                         else
                         {
-                            <div class="d-flex justify-center align-center" style="height: 160px; background-color: var(--mud-palette-background-grey);">
+                            <div class="d-flex justify-center align-center h-160" style="background-color: var(--mud-palette-background-grey);">
                                 <MudIcon Icon="@Icons.Material.Filled.HideImage" Size="Size.Large" Color="Color.Secondary" />
                             </div>
                         }
                         <MudCardContent>
                             <MudText Typo="Typo.h6">@(sighting.SpeciesName ?? L["Sightings_UnknownSpecies"])</MudText>
                             <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-1">
-                                <MudIcon Icon="@Icons.Material.Filled.CalendarToday" Size="Size.Small" Class="mr-1" Style="vertical-align: middle;" />
+                                <MudIcon Icon="@Icons.Material.Filled.CalendarToday" Size="Size.Small" Class="mr-1 align-middle" />
                                 @sighting.ObservedAt.ToLocalTime().ToString("MMM dd, yyyy HH:mm")
                             </MudText>
                             <MudText Typo="Typo.body2" Color="Color.Secondary">
-                                <MudIcon Icon="@Icons.Material.Filled.LocationOn" Size="Size.Small" Class="mr-1" Style="vertical-align: middle;" />
+                                <MudIcon Icon="@Icons.Material.Filled.LocationOn" Size="Size.Small" Class="mr-1 align-middle" />
                                 @sighting.Latitude.ToString("F4"), @sighting.Longitude.ToString("F4")
                             </MudText>
                         </MudCardContent>
@@ -218,13 +218,11 @@
                         <MudImage Src="@($"/api/wildlife/sightings/{_detailsSighting.Id}/photo")"
                                   Alt="Sighting photo"
                                   ObjectFit="ObjectFit.Cover"
-                                  Class="rounded-lg mb-3"
-                                  Style="width: 100%; max-height: 300px;" />
+                                  Class="rounded-lg mb-3 w-full max-h-300" />
                     }
                     else
                     {
-                        <div class="d-flex justify-center align-center rounded-lg mb-3"
-                             style="height: 200px; background-color: var(--mud-palette-background-grey);">
+                        <div class="d-flex justify-center align-center rounded-lg mb-3 h-200" style="background-color: var(--mud-palette-background-grey);">
                             <MudStack AlignItems="AlignItems.Center">
                                 <MudIcon Icon="@Icons.Material.Filled.HideImage" Size="Size.Large" Color="Color.Secondary" />
                                 <MudText Color="Color.Secondary">@L["SightingDetail_NoPhoto"]</MudText>

--- a/src/FaunaFinder.Client/Pages/Admin/UserDetails.razor
+++ b/src/FaunaFinder.Client/Pages/Admin/UserDetails.razor
@@ -50,7 +50,7 @@
                 <MudSimpleTable Dense="true" Hover="true">
                     <tbody>
                         <tr>
-                            <td style="width: 40%;"><strong>@L["Admin_DisplayName"]</strong></td>
+                            <td class="w-40-percent"><strong>@L["Admin_DisplayName"]</strong></td>
                             <td>@_user.DisplayName</td>
                         </tr>
                         <tr>

--- a/src/FaunaFinder.Client/Pages/Admin/Users.razor
+++ b/src/FaunaFinder.Client/Pages/Admin/Users.razor
@@ -91,7 +91,7 @@
 
         @if (_hasMore)
         {
-            <div @ref="_sentinel" style="height: 1px;"></div>
+            <div @ref="_sentinel" class="h-1"></div>
         }
     }
 </MudContainer>

--- a/src/FaunaFinder.Client/Pages/Home.razor
+++ b/src/FaunaFinder.Client/Pages/Home.razor
@@ -1,21 +1,22 @@
 @page "/"
 @using BlazingSingularity.Commands
 @using FaunaFinder.Client.Pages.MapComponents
+@using FaunaFinder.Client.Services.Map
 @inject IMunicipalityHttpClient MunicipalityHttpClient
 @inject ISpeciesHttpClient SpeciesHttpClient
 @inject IExportHttpClient ExportHttpClient
-@inject ApiConfiguration ApiConfig
 @inject NavigationManager NavigationManager
-@inject IJSRuntime JS
 @inject IAppLocalizer L
+@inject IMapService MapService
 @inject ISnackbar Snackbar
 @inject IDarkModeService DarkModeService
 @implements IDisposable
 
+
 <PageTitle>@L["PageTitle_Map"]</PageTitle>
 
 <div class="map-page">
-    <div class="map-container" style="position: relative;">
+    <div class="map-container relative">
         @if (isMapLoading)
         {
             <MudOverlay Visible="true" DarkBackground="false" Absolute="true" Class="map-loading-overlay" ZIndex="1000">
@@ -39,7 +40,7 @@
                     <div class="pa-3">
                         @for (int i = 0; i < 8; i++)
                         {
-                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="60px" Class="mb-3 rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
+                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="60px" Class="mb-3 rounded skeleton-border" />
                         }
                     </div>
                 }
@@ -54,7 +55,7 @@
                             <div class="d-flex align-center gap-2 flex-wrap">
                                 <MudSelect T="SortOption" Value="currentSort" ValueChanged="OnSortChanged"
                                            Dense="true" Margin="Margin.Dense" Variant="Variant.Outlined"
-                                           Style="max-width: 150px;" Label="@L["Filter_Sort"]">
+                                           Class="max-w-150" Label="@L["Filter_Sort"]">
                                     <MudSelectItem Value="SortOption.NameAZ">@L["Filter_NameAZ"]</MudSelectItem>
                                     <MudSelectItem Value="SortOption.NameZA">@L["Filter_NameZA"]</MudSelectItem>
                                     <MudSelectItem Value="SortOption.ScientificAZ">@L["Filter_ScientificAZ"]</MudSelectItem>
@@ -286,7 +287,7 @@
                         <div class="d-flex align-center gap-2">
                             <MudSelect T="SortOption" Value="currentSort" ValueChanged="OnSortChanged"
                                        Dense="true" Margin="Margin.Dense" Variant="Variant.Outlined"
-                                       Style="flex: 1;" Label="@L["Filter_Sort"]">
+                                       Class="flex-1" Label="@L["Filter_Sort"]">
                                 <MudSelectItem Value="SortOption.NameAZ">@L["Filter_NameAZ"]</MudSelectItem>
                                 <MudSelectItem Value="SortOption.NameZA">@L["Filter_NameZA"]</MudSelectItem>
                                 <MudSelectItem Value="SortOption.ScientificAZ">@L["Filter_ScientificAZ"]</MudSelectItem>
@@ -325,7 +326,7 @@
                     <div class="pa-3">
                         @for (int i = 0; i < 8; i++)
                         {
-                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="60px" Class="mb-3 rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
+                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="60px" Class="mb-3 rounded skeleton-border" />
                         }
                     </div>
                 }
@@ -647,8 +648,7 @@
 
     private async Task DownloadFile(byte[] fileBytes, string fileName, string contentType)
     {
-        var base64 = Convert.ToBase64String(fileBytes);
-        await JS.InvokeVoidAsync("downloadFile", base64, fileName, contentType);
+        await MapService.DownloadFileAsync(fileBytes, fileName, contentType);
     }
 
     private void ToggleSpecies(int speciesId, bool expanded)
@@ -666,7 +666,7 @@
         if (firstRender)
         {
             municipalities = await MunicipalityHttpClient.GetAllMunicipalitiesAsync();
-            await JS.InvokeVoidAsync("leafletInterop.initMap", DotNetObjectReference.Create(this), ApiConfig.BaseAddress);
+            await MapService.InitMapAsync(DotNetObjectReference.Create(this));
             isMapInitialized = true;
 
             // Subscribe to dark mode changes after map is initialized
@@ -693,7 +693,7 @@
             {
                 await InvokeAsync(async () =>
                 {
-                    await JS.InvokeVoidAsync("leafletInterop.setDarkMode", DarkModeService.IsDarkMode);
+                    await MapService.SetDarkModeAsync(DarkModeService.IsDarkMode);
                 });
             }
             catch (Exception ex)
@@ -709,25 +709,20 @@
         currentLocationIndex = 0;
         if (viewingSpeciesLocations?.Locations.Count > 0)
         {
-            var locations = viewingSpeciesLocations.Locations.Select(l => new
-            {
-                latitude = l.Latitude,
-                longitude = l.Longitude,
-                radiusMeters = l.RadiusMeters,
-                description = l.Description
-            }).ToArray();
+            var locations = viewingSpeciesLocations.Locations.Select(l =>
+                new SpeciesLocationData(l.Latitude, l.Longitude, l.RadiusMeters, l.Description));
 
-            await JS.InvokeVoidAsync("leafletInterop.showSpeciesLocations", L.GetLocalizedValue(viewingSpeciesLocations.CommonName), locations);
+            await MapService.ShowSpeciesLocationsAsync(L.GetLocalizedValue(viewingSpeciesLocations.CommonName), locations);
 
             // Focus on the first location
-            await JS.InvokeVoidAsync("leafletInterop.focusOnLocation", 0);
+            await MapService.FocusOnLocationAsync(0);
         }
         StateHasChanged();
     }
 
     private async Task ClearSpeciesLocations()
     {
-        await JS.InvokeVoidAsync("leafletInterop.clearSpeciesLocations");
+        await MapService.ClearSpeciesLocationsAsync();
         viewingSpeciesLocations = null;
         currentLocationIndex = 0;
         sheetOpen = false;
@@ -736,12 +731,12 @@
 
     private async Task FocusOnLocation(int index)
     {
-        await JS.InvokeVoidAsync("leafletInterop.focusOnLocation", index);
+        await MapService.FocusOnLocationAsync(index);
     }
 
     private async Task FocusAllLocations()
     {
-        await JS.InvokeVoidAsync("leafletInterop.focusAllLocations");
+        await MapService.FocusAllLocationsAsync();
     }
 
     private async Task PreviousLocation()
@@ -789,7 +784,7 @@
         sidebarOpen = true;
 
         // Clear nearby species search
-        await JS.InvokeVoidAsync("leafletInterop.clearSearchRadius");
+        await MapService.ClearSearchRadiusAsync();
 
         // Reset filters when switching municipalities
         ClearAllFilters();
@@ -852,7 +847,7 @@
         nearbySpecies = [];
         expandedSpeciesId = null;
         ClearAllFilters();
-        await JS.InvokeVoidAsync("leafletInterop.clearSearchRadius");
+        await MapService.ClearSearchRadiusAsync();
         StateHasChanged();
     }
 
@@ -884,8 +879,8 @@
         // Clear existing species location circles if shown
         if (showSpeciesLocationsOnMap)
         {
-            await JS.InvokeVoidAsync("leafletInterop.clearSpeciesLocationCircles");
-            await JS.InvokeVoidAsync("leafletInterop.resetSpeciesColors");
+            await MapService.ClearSpeciesLocationCirclesAsync();
+            await MapService.ResetSpeciesColorsAsync();
             showSpeciesLocationsOnMap = false;
             speciesColors.Clear();
         }
@@ -898,7 +893,7 @@
             var radiusMeters = selectedRadiusKm * 1000.0;
 
             // Show search radius on map
-            await JS.InvokeVoidAsync("leafletInterop.showSearchRadius", radiusMeters);
+            await MapService.ShowSearchRadiusAsync(radiusMeters);
 
             // Query nearby species
             nearbySpecies = await SpeciesHttpClient.GetSpeciesNearbyAsync(
@@ -907,19 +902,18 @@
                 radiusMeters);
 
             // Show nearby species on map
-            var speciesLocations = nearbySpecies.Select(s => new
-            {
-                id = s.Id,
-                commonName = s.CommonName,
-                scientificName = s.ScientificName,
-                distanceMeters = s.DistanceMeters,
-                latitude = s.Latitude,
-                longitude = s.Longitude,
-                radiusMeters = s.RadiusMeters,
-                locationDescription = s.LocationDescription
-            }).ToArray();
+            var speciesLocations = nearbySpecies.Select(s =>
+                new NearbySpeciesData(
+                    s.Id,
+                    s.CommonName,
+                    s.ScientificName,
+                    s.DistanceMeters,
+                    s.Latitude,
+                    s.Longitude,
+                    s.RadiusMeters,
+                    s.LocationDescription));
 
-            await JS.InvokeVoidAsync("leafletInterop.showNearbySpecies", speciesLocations);
+            await MapService.ShowNearbySpeciesAsync(speciesLocations);
         }
         finally
         {
@@ -942,15 +936,15 @@
         sheetOpen = false;
         showSpeciesLocationsOnMap = false;
         speciesColors.Clear();
-        await JS.InvokeVoidAsync("leafletInterop.clearSearchRadius");
-        await JS.InvokeVoidAsync("leafletInterop.clearSpeciesLocationCircles");
-        await JS.InvokeVoidAsync("leafletInterop.resetSpeciesColors");
+        await MapService.ClearSearchRadiusAsync();
+        await MapService.ClearSpeciesLocationCirclesAsync();
+        await MapService.ResetSpeciesColorsAsync();
         StateHasChanged();
     }
 
     private async Task FocusOnNearbySpecies(int index)
     {
-        await JS.InvokeVoidAsync("leafletInterop.focusOnNearbySpecies", index);
+        await MapService.FocusOnNearbySpeciesAsync(index);
     }
 
     private async Task ToggleSpeciesLocationsOnMap()
@@ -960,37 +954,32 @@
         if (showSpeciesLocationsOnMap)
         {
             // Show species location circles on the map
-            var speciesLocations = nearbySpecies.Select(s => new
-            {
-                id = s.Id,
-                commonName = s.CommonName,
-                scientificName = s.ScientificName,
-                distanceMeters = s.DistanceMeters,
-                latitude = s.Latitude,
-                longitude = s.Longitude,
-                radiusMeters = s.RadiusMeters,
-                locationDescription = s.LocationDescription
-            }).ToArray();
+            var speciesLocations = nearbySpecies.Select(s =>
+                new NearbySpeciesData(
+                    s.Id,
+                    s.CommonName,
+                    s.ScientificName,
+                    s.DistanceMeters,
+                    s.Latitude,
+                    s.Longitude,
+                    s.RadiusMeters,
+                    s.LocationDescription));
 
-            await JS.InvokeVoidAsync("leafletInterop.showSpeciesLocationCircles", speciesLocations);
+            await MapService.ShowSpeciesLocationCirclesAsync(speciesLocations);
 
             // Get colors assigned to each species
-            var colors = await JS.InvokeAsync<List<SpeciesColorEntry>>("leafletInterop.getSpeciesColors");
+            var colors = await MapService.GetSpeciesColorsAsync();
             speciesColors = colors.ToDictionary(c => c.Id, c => c.Color);
         }
         else
         {
             // Hide species location circles
-            await JS.InvokeVoidAsync("leafletInterop.clearSpeciesLocationCircles");
+            await MapService.ClearSpeciesLocationCirclesAsync();
             speciesColors.Clear();
         }
 
         StateHasChanged();
     }
-
-    private record SpeciesColorEntry(
-        [property: System.Text.Json.Serialization.JsonPropertyName("id")] int Id,
-        [property: System.Text.Json.Serialization.JsonPropertyName("color")] string Color);
 
     // State preservation for Species Near Me
     private async Task NavigateToSpeciesDetail(int speciesId)
@@ -1010,7 +999,7 @@
                 longitude = userLongitude.Value,
                 radiusKm = selectedRadiusKm
             };
-            await JS.InvokeVoidAsync("sessionStorage.setItem", "nearbySpeciesState", System.Text.Json.JsonSerializer.Serialize(state));
+            await MapService.SetSessionStorageAsync("nearbySpeciesState", System.Text.Json.JsonSerializer.Serialize(state));
         }
     }
 
@@ -1018,7 +1007,7 @@
     {
         try
         {
-            var stateJson = await JS.InvokeAsync<string?>("sessionStorage.getItem", "nearbySpeciesState");
+            var stateJson = await MapService.GetSessionStorageAsync("nearbySpeciesState");
             if (!string.IsNullOrEmpty(stateJson))
             {
                 var state = System.Text.Json.JsonSerializer.Deserialize<NearbySpeciesState>(stateJson);
@@ -1029,7 +1018,7 @@
                     selectedRadiusKm = state.RadiusKm;
 
                     // Clear the saved state
-                    await JS.InvokeVoidAsync("sessionStorage.removeItem", "nearbySpeciesState");
+                    await MapService.RemoveSessionStorageAsync("nearbySpeciesState");
 
                     // Clear the query parameter from URL
                     NavigationManager.NavigateTo("/", replace: true);

--- a/src/FaunaFinder.Client/Pages/Login.razor
+++ b/src/FaunaFinder.Client/Pages/Login.razor
@@ -41,7 +41,7 @@
                         </MudAlert>
                     }
 
-                    <EditForm Model="_model" OnValidSubmit="HandleLogin" style="width: 100%;">
+                    <EditForm Model="_model" OnValidSubmit="HandleLogin" class="w-full">
                         <DataAnnotationsValidator />
 
                         <MudTextField @bind-Value="_model.Email"

--- a/src/FaunaFinder.Client/Pages/MapComponents/LoadingPanel.razor
+++ b/src/FaunaFinder.Client/Pages/MapComponents/LoadingPanel.razor
@@ -1,4 +1,4 @@
-<MudContainer Class="d-flex flex-column align-center justify-center" Style="height: 200px;">
+<MudContainer Class="d-flex flex-column align-center justify-center h-200">
     <MudProgressCircular Color="@Color" Indeterminate="true" />
     <MudText Typo="Typo.body2" Class="mt-3">@Message</MudText>
 </MudContainer>

--- a/src/FaunaFinder.Client/Pages/MapComponents/LocationNavigator.razor
+++ b/src/FaunaFinder.Client/Pages/MapComponents/LocationNavigator.razor
@@ -3,7 +3,7 @@
 <div class="location-nav-overlay">
     <div class="location-nav-header">
         <MudIcon Icon="@Icons.Material.Filled.MyLocation" Size="Size.Small" Class="mr-2" />
-        <MudText Typo="Typo.body2" Style="font-weight: 500;">@L.GetLocalizedValue(Species.CommonName)</MudText>
+        <MudText Typo="Typo.body2" Class="font-medium">@L.GetLocalizedValue(Species.CommonName)</MudText>
         <MudSpacer />
         <MudButton Variant="Variant.Text"
                    Size="Size.Small"

--- a/src/FaunaFinder.Client/Pages/NotFound.razor
+++ b/src/FaunaFinder.Client/Pages/NotFound.razor
@@ -3,7 +3,7 @@
 
 <PageTitle>Not Found - FaunaFinder</PageTitle>
 
-<MudContainer MaxWidth="MaxWidth.Small" Class="d-flex flex-column align-center justify-center" Style="height: calc(100vh - 64px);">
+<MudContainer MaxWidth="MaxWidth.Small" Class="d-flex flex-column align-center justify-center h-full-minus-appbar">
     <MudPaper Elevation="3" Class="pa-6 text-center">
         <MudIcon Icon="@Icons.Material.Filled.SearchOff" Color="Color.Warning" Size="Size.Large" Class="mb-4" />
         <MudText Typo="Typo.h5" Class="mb-2">Page Not Found</MudText>

--- a/src/FaunaFinder.Client/Pages/Profile.razor
+++ b/src/FaunaFinder.Client/Pages/Profile.razor
@@ -23,7 +23,7 @@
                         @authContext.User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value
                     </MudText>
 
-                    <MudDivider Class="my-4" Style="width: 100%;" />
+                    <MudDivider Class="my-4 w-full" />
 
                     <MudList T="string" Dense="true" Class="w-100">
                         <MudListItem Icon="@Icons.Material.Filled.Badge">
@@ -44,7 +44,7 @@
                         </MudListItem>
                     </MudList>
 
-                    <MudDivider Class="my-4" Style="width: 100%;" />
+                    <MudDivider Class="my-4 w-full" />
 
                     <MudButton Variant="Variant.Filled"
                                Color="Color.Error"

--- a/src/FaunaFinder.Client/Pages/PuebloDetail.razor
+++ b/src/FaunaFinder.Client/Pages/PuebloDetail.razor
@@ -21,8 +21,8 @@
     @if (LoadMunicipalityCommand.IsLoading)
     {
         <MudPaper Elevation="2" Class="pa-4 mb-6">
-            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="40px" Width="50%" Class="mb-3 rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
-            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="24px" Width="30%" Class="rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="40px" Width="50%" Class="mb-3 rounded skeleton-border" />
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="24px" Width="30%" Class="rounded skeleton-border" />
         </MudPaper>
     }
     else if (municipality == null)
@@ -53,7 +53,7 @@
         {
             @for (int i = 0; i < 6; i++)
             {
-                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="60px" Class="mb-3 rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="60px" Class="mb-3 rounded skeleton-border" />
             }
         }
         else if (species.Count == 0)

--- a/src/FaunaFinder.Client/Pages/Pueblos.razor
+++ b/src/FaunaFinder.Client/Pages/Pueblos.razor
@@ -30,7 +30,7 @@
             @for (int i = 0; i < 20; i++)
             {
                 <MudItem xs="12" sm="6" md="4" lg="3">
-                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="80px" Class="rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
+                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="80px" Class="rounded skeleton-border" />
                 </MudItem>
             }
         </MudGrid>

--- a/src/FaunaFinder.Client/Pages/Register.razor
+++ b/src/FaunaFinder.Client/Pages/Register.razor
@@ -56,7 +56,7 @@
                     }
                     else
                     {
-                        <EditForm Model="_model" OnValidSubmit="HandleRegister" style="width: 100%;">
+                        <EditForm Model="_model" OnValidSubmit="HandleRegister" class="w-full">
                             <DataAnnotationsValidator />
 
                             <MudTextField @bind-Value="_model.DisplayName"

--- a/src/FaunaFinder.Client/Pages/Species.razor
+++ b/src/FaunaFinder.Client/Pages/Species.razor
@@ -30,7 +30,7 @@
             @for (int i = 0; i < 20; i++)
             {
                 <MudItem xs="12" sm="6" md="4" lg="3">
-                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="100px" Class="rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
+                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="100px" Class="rounded skeleton-border" />
                 </MudItem>
             }
         </MudGrid>

--- a/src/FaunaFinder.Client/Pages/SpeciesDetail.razor
+++ b/src/FaunaFinder.Client/Pages/SpeciesDetail.razor
@@ -19,26 +19,26 @@
     @if (LoadDataCommand.IsLoading)
     {
         <MudPaper Elevation="2" Class="pa-4 mb-6">
-            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="40px" Class="mb-3 rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
-            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="24px" Width="60%" Class="mb-3 rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
-            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="20px" Width="40%" Class="mb-3 rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
-            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="36px" Width="150px" Class="rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="40px" Class="mb-3 rounded skeleton-border" />
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="24px" Width="60%" Class="mb-3 rounded skeleton-border" />
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="20px" Width="40%" Class="mb-3 rounded skeleton-border" />
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="36px" Width="150px" Class="rounded skeleton-border" />
         </MudPaper>
 
-        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="32px" Width="200px" Class="mb-4 rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
+        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="32px" Width="200px" Class="mb-4 rounded skeleton-border" />
         <MudGrid Spacing="3" Class="mb-6">
             @for (int i = 0; i < 4; i++)
             {
                 <MudItem xs="6" sm="4" md="3">
-                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="50px" Class="rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
+                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="50px" Class="rounded skeleton-border" />
                 </MudItem>
             }
         </MudGrid>
 
-        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="32px" Width="250px" Class="mb-4 rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
+        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="32px" Width="250px" Class="mb-4 rounded skeleton-border" />
         @for (int i = 0; i < 2; i++)
         {
-            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="120px" Class="mb-3 rounded" Style="border: 1px solid rgba(255,255,255,0.1);" />
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="120px" Class="mb-3 rounded skeleton-border" />
         }
     }
     else if (species == null)
@@ -58,8 +58,7 @@
                         <MudImage Src="@GetProfileImageUrl()"
                                   Alt="@L.GetLocalizedValue(species.CommonName)"
                                   ObjectFit="ObjectFit.Cover"
-                                  Class="rounded-lg species-image"
-                                  Style="width: 100%; max-height: 200px;" />
+                                  Class="rounded-lg species-image w-full max-h-200" />
                         @if (!string.IsNullOrEmpty(species.ImageSourceUrl))
                         {
                             <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1">
@@ -150,7 +149,7 @@
                                    Margin="Margin.Dense"
                                    Dense="true"
                                    Clearable="true"
-                                   Style="min-width: 150px;">
+                                   Class="min-w-150">
                             @foreach (var practice in AvailableNrcsPractices)
                             {
                                 <MudSelectItem Value="@practice">@practice</MudSelectItem>
@@ -164,7 +163,7 @@
                                    Margin="Margin.Dense"
                                    Dense="true"
                                    Clearable="true"
-                                   Style="min-width: 150px;">
+                                   Class="min-w-150">
                             @foreach (var action in AvailableFwsActions)
                             {
                                 <MudSelectItem Value="@action">@action</MudSelectItem>

--- a/src/FaunaFinder.Client/Pages/Wildlife/MySightings.razor
+++ b/src/FaunaFinder.Client/Pages/Wildlife/MySightings.razor
@@ -51,7 +51,7 @@
                         }
                         else
                         {
-                            <div class="d-flex justify-center align-center" style="height: 160px; background-color: var(--mud-palette-background-grey);">
+                            <div class="d-flex justify-center align-center h-160" style="background-color: var(--mud-palette-background-grey);">
                                 <MudIcon Icon="@Icons.Material.Filled.HideImage" Size="Size.Large" Color="Color.Secondary" />
                             </div>
                         }

--- a/src/FaunaFinder.Client/Pages/Wildlife/SightingDetail.razor
+++ b/src/FaunaFinder.Client/Pages/Wildlife/SightingDetail.razor
@@ -74,13 +74,11 @@
                         <MudImage Src="@($"/api/wildlife/sightings/{_sighting.Id}/photo?v={_photoVersion}")"
                                   Alt="@L["SightingDetail_PhotoAlt"]"
                                   ObjectFit="ObjectFit.Cover"
-                                  Class="rounded-lg"
-                                  Style="width: 100%; max-height: 400px;" />
+                                  Class="rounded-lg w-full max-h-400" />
                     }
                     else
                     {
-                        <div class="d-flex justify-center align-center rounded-lg"
-                             style="height: 200px; background-color: var(--mud-palette-background-grey);">
+                        <div class="d-flex justify-center align-center rounded-lg h-200" style="background-color: var(--mud-palette-background-grey);">
                             <MudStack AlignItems="AlignItems.Center">
                                 <MudIcon Icon="@Icons.Material.Filled.HideImage" Size="Size.Large" Color="Color.Secondary" />
                                 <MudText Color="Color.Secondary">@L["SightingDetail_NoPhoto"]</MudText>
@@ -123,7 +121,7 @@
                 @* Location Map *@
                 <MudPaper Elevation="2" Class="pa-4">
                     <MudText Typo="Typo.h6" Class="mb-3">@L["SightingDetail_Location"]</MudText>
-                    <div id="sighting-map" class="rounded-lg" style="height: 300px; width: 100%;"></div>
+                    <div id="sighting-map" class="rounded-lg h-300 w-full"></div>
                     <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-2">
                         @_sighting.Latitude.ToString("F6"), @_sighting.Longitude.ToString("F6")
                     </MudText>
@@ -196,7 +194,7 @@
                 {
                     <MudPaper Elevation="2" Class="pa-4 mb-4">
                         <MudText Typo="Typo.h6" Class="mb-2">@L["SightingDetail_Notes"]</MudText>
-                        <MudText Typo="Typo.body1" Style="white-space: pre-wrap;">@_sighting.Notes</MudText>
+                        <MudText Typo="Typo.body1" Class="whitespace-pre-wrap">@_sighting.Notes</MudText>
                     </MudPaper>
                 }
 
@@ -237,7 +235,7 @@
                             {
                                 <MudItem xs="12">
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">@L["SightingDetail_ReviewNotes"]</MudText>
-                                    <MudText Typo="Typo.body1" Style="white-space: pre-wrap;">@_sighting.ReviewNotes</MudText>
+                                    <MudText Typo="Typo.body1" Class="whitespace-pre-wrap">@_sighting.ReviewNotes</MudText>
                                 </MudItem>
                             }
                         </MudGrid>

--- a/src/FaunaFinder.Client/Program.cs
+++ b/src/FaunaFinder.Client/Program.cs
@@ -5,6 +5,7 @@ using FaunaFinder.Client.Services.Api;
 using FaunaFinder.Client.Services.Auth;
 using FaunaFinder.Client.Services.DarkMode;
 using FaunaFinder.Client.Services.Localization;
+using FaunaFinder.Client.Services.Map;
 using FaunaFinder.Identity.Application.Client;
 using FaunaFinder.Wildlife.Application.Client;
 
@@ -23,6 +24,7 @@ builder.Services.AddSingleton(new ApiConfiguration(baseAddress.ToString()));
 // Register application services
 builder.Services.AddSingleton<IAppLocalizer, AppLocalizer>();
 builder.Services.AddSingleton<IDarkModeService, DarkModeService>();
+builder.Services.AddScoped<IMapService, MapService>();
 
 // Authentication
 builder.Services.AddScoped<CookieAuthenticationStateProvider>();

--- a/src/FaunaFinder.Client/Services/Map/IMapService.cs
+++ b/src/FaunaFinder.Client/Services/Map/IMapService.cs
@@ -1,0 +1,48 @@
+using FaunaFinder.i18n.Contracts;
+using Microsoft.JSInterop;
+
+namespace FaunaFinder.Client.Services.Map;
+
+public interface IMapService
+{
+    Task InitMapAsync<T>(DotNetObjectReference<T> callbackHandler) where T : class;
+    Task SetDarkModeAsync(bool isDarkMode);
+    Task ShowSearchRadiusAsync(double radiusMeters);
+    Task ClearSearchRadiusAsync();
+    Task ShowSpeciesLocationsAsync(string commonName, IEnumerable<SpeciesLocationData> locations);
+    Task ClearSpeciesLocationsAsync();
+    Task FocusOnLocationAsync(int index);
+    Task FocusAllLocationsAsync();
+    Task ShowNearbySpeciesAsync(IEnumerable<NearbySpeciesData> species);
+    Task FocusOnNearbySpeciesAsync(int index);
+    Task ShowSpeciesLocationCirclesAsync(IEnumerable<NearbySpeciesData> species);
+    Task ClearSpeciesLocationCirclesAsync();
+    Task ResetSpeciesColorsAsync();
+    Task<List<SpeciesColorEntry>> GetSpeciesColorsAsync();
+    Task DownloadFileAsync(byte[] fileBytes, string fileName, string contentType);
+
+    // Session storage methods for state preservation
+    Task SetSessionStorageAsync(string key, string value);
+    Task<string?> GetSessionStorageAsync(string key);
+    Task RemoveSessionStorageAsync(string key);
+}
+
+public record SpeciesLocationData(
+    double Latitude,
+    double Longitude,
+    double RadiusMeters,
+    string? Description);
+
+public record NearbySpeciesData(
+    int Id,
+    IEnumerable<LocaleValue> CommonName,
+    string ScientificName,
+    double DistanceMeters,
+    double Latitude,
+    double Longitude,
+    double RadiusMeters,
+    string? LocationDescription);
+
+public record SpeciesColorEntry(
+    [property: System.Text.Json.Serialization.JsonPropertyName("id")] int Id,
+    [property: System.Text.Json.Serialization.JsonPropertyName("color")] string Color);

--- a/src/FaunaFinder.Client/Services/Map/MapService.cs
+++ b/src/FaunaFinder.Client/Services/Map/MapService.cs
@@ -1,0 +1,139 @@
+using FaunaFinder.Client.Services.Api;
+using Microsoft.JSInterop;
+
+namespace FaunaFinder.Client.Services.Map;
+
+public sealed class MapService : IMapService
+{
+    private readonly IJSRuntime _js;
+    private readonly ApiConfiguration _apiConfig;
+
+    public MapService(IJSRuntime js, ApiConfiguration apiConfig)
+    {
+        _js = js;
+        _apiConfig = apiConfig;
+    }
+
+    public async Task InitMapAsync<T>(DotNetObjectReference<T> callbackHandler) where T : class
+    {
+        await _js.InvokeVoidAsync("leafletInterop.initMap", callbackHandler, _apiConfig.BaseAddress);
+    }
+
+    public async Task SetDarkModeAsync(bool isDarkMode)
+    {
+        await _js.InvokeVoidAsync("leafletInterop.setDarkMode", isDarkMode);
+    }
+
+    public async Task ShowSearchRadiusAsync(double radiusMeters)
+    {
+        await _js.InvokeVoidAsync("leafletInterop.showSearchRadius", radiusMeters);
+    }
+
+    public async Task ClearSearchRadiusAsync()
+    {
+        await _js.InvokeVoidAsync("leafletInterop.clearSearchRadius");
+    }
+
+    public async Task ShowSpeciesLocationsAsync(string commonName, IEnumerable<SpeciesLocationData> locations)
+    {
+        var jsLocations = locations.Select(l => new
+        {
+            latitude = l.Latitude,
+            longitude = l.Longitude,
+            radiusMeters = l.RadiusMeters,
+            description = l.Description
+        }).ToArray();
+
+        await _js.InvokeVoidAsync("leafletInterop.showSpeciesLocations", commonName, jsLocations);
+    }
+
+    public async Task ClearSpeciesLocationsAsync()
+    {
+        await _js.InvokeVoidAsync("leafletInterop.clearSpeciesLocations");
+    }
+
+    public async Task FocusOnLocationAsync(int index)
+    {
+        await _js.InvokeVoidAsync("leafletInterop.focusOnLocation", index);
+    }
+
+    public async Task FocusAllLocationsAsync()
+    {
+        await _js.InvokeVoidAsync("leafletInterop.focusAllLocations");
+    }
+
+    public async Task ShowNearbySpeciesAsync(IEnumerable<NearbySpeciesData> species)
+    {
+        var jsSpecies = species.Select(s => new
+        {
+            id = s.Id,
+            commonName = s.CommonName,
+            scientificName = s.ScientificName,
+            distanceMeters = s.DistanceMeters,
+            latitude = s.Latitude,
+            longitude = s.Longitude,
+            radiusMeters = s.RadiusMeters,
+            locationDescription = s.LocationDescription
+        }).ToArray();
+
+        await _js.InvokeVoidAsync("leafletInterop.showNearbySpecies", jsSpecies);
+    }
+
+    public async Task FocusOnNearbySpeciesAsync(int index)
+    {
+        await _js.InvokeVoidAsync("leafletInterop.focusOnNearbySpecies", index);
+    }
+
+    public async Task ShowSpeciesLocationCirclesAsync(IEnumerable<NearbySpeciesData> species)
+    {
+        var jsSpecies = species.Select(s => new
+        {
+            id = s.Id,
+            commonName = s.CommonName,
+            scientificName = s.ScientificName,
+            distanceMeters = s.DistanceMeters,
+            latitude = s.Latitude,
+            longitude = s.Longitude,
+            radiusMeters = s.RadiusMeters,
+            locationDescription = s.LocationDescription
+        }).ToArray();
+
+        await _js.InvokeVoidAsync("leafletInterop.showSpeciesLocationCircles", jsSpecies);
+    }
+
+    public async Task ClearSpeciesLocationCirclesAsync()
+    {
+        await _js.InvokeVoidAsync("leafletInterop.clearSpeciesLocationCircles");
+    }
+
+    public async Task ResetSpeciesColorsAsync()
+    {
+        await _js.InvokeVoidAsync("leafletInterop.resetSpeciesColors");
+    }
+
+    public async Task<List<SpeciesColorEntry>> GetSpeciesColorsAsync()
+    {
+        return await _js.InvokeAsync<List<SpeciesColorEntry>>("leafletInterop.getSpeciesColors");
+    }
+
+    public async Task DownloadFileAsync(byte[] fileBytes, string fileName, string contentType)
+    {
+        var base64 = Convert.ToBase64String(fileBytes);
+        await _js.InvokeVoidAsync("downloadFile", base64, fileName, contentType);
+    }
+
+    public async Task SetSessionStorageAsync(string key, string value)
+    {
+        await _js.InvokeVoidAsync("sessionStorage.setItem", key, value);
+    }
+
+    public async Task<string?> GetSessionStorageAsync(string key)
+    {
+        return await _js.InvokeAsync<string?>("sessionStorage.getItem", key);
+    }
+
+    public async Task RemoveSessionStorageAsync(string key)
+    {
+        await _js.InvokeVoidAsync("sessionStorage.removeItem", key);
+    }
+}

--- a/src/FaunaFinder.Server/wwwroot/css/app.css
+++ b/src/FaunaFinder.Server/wwwroot/css/app.css
@@ -532,3 +532,99 @@ body {
     margin-top: 4px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
+
+/* ==========================================================================
+   Utility Classes
+   ========================================================================== */
+
+/* Skeleton loading border */
+.skeleton-border {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+/* Height utilities */
+.h-full-minus-appbar {
+    height: calc(100vh - 64px);
+}
+
+.h-160 {
+    height: 160px;
+}
+
+.h-200 {
+    height: 200px;
+}
+
+.h-300 {
+    height: 300px;
+}
+
+.h-1 {
+    height: 1px;
+}
+
+/* Width utilities */
+.w-full {
+    width: 100%;
+}
+
+.w-40-percent {
+    width: 40%;
+}
+
+.min-w-150 {
+    min-width: 150px;
+}
+
+.max-w-150 {
+    max-width: 150px;
+}
+
+.max-h-200 {
+    max-height: 200px;
+}
+
+.max-h-300 {
+    max-height: 300px;
+}
+
+.max-h-400 {
+    max-height: 400px;
+}
+
+/* Font utilities */
+.font-medium {
+    font-weight: 500;
+}
+
+.font-semibold {
+    font-weight: 600;
+}
+
+.italic {
+    font-style: italic;
+}
+
+.whitespace-pre-wrap {
+    white-space: pre-wrap;
+}
+
+/* Cursor utilities */
+.cursor-pointer {
+    cursor: pointer;
+}
+
+/* Alignment utilities */
+.align-middle {
+    vertical-align: middle;
+}
+
+/* Flex utilities */
+.flex-1 {
+    flex: 1;
+}
+
+/* Position utilities */
+.relative {
+    position: relative;
+}


### PR DESCRIPTION
## Summary
- Create `IMapService` and `MapService` to wrap all leaflet JS interop calls, removing direct `IJSRuntime` and `ApiConfiguration` injection from Home.razor
- Add CSS utility classes in `app.css` for common patterns (heights, widths, fonts, skeleton borders, etc.)
- Replace inline styles across 20+ components with reusable utility classes

## Test plan
- [ ] Verify map functionality works correctly (init, dark mode toggle, species locations, nearby species)
- [ ] Verify all pages render correctly with the new CSS classes
- [ ] Test responsive behavior on mobile and desktop
- [ ] Verify dark/light mode themes still work properly