### PR TITLE
UI: Improve species detail text readability in map sidebar

### DIFF
--- a/src/FaunaFinder.Client/Components/ConservationLinkCard.razor
+++ b/src/FaunaFinder.Client/Components/ConservationLinkCard.razor
@@ -1,20 +1,20 @@
-<MudPaper Elevation="0" Class="pa-2 mb-2 bg-subtle">
-    <div class="d-flex align-start gap-2 mb-1">
+<MudPaper Elevation="0" Class="pa-3 mb-2 bg-subtle">
+    <div class="d-flex align-start gap-2 mb-2">
         <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Filled">
             NRCS @Link.NrcsPractice.Code
         </MudChip>
-        <MudText Typo="Typo.body2">@Link.NrcsPractice.Name</MudText>
+        <MudText Typo="Typo.body1">@Link.NrcsPractice.Name</MudText>
     </div>
-    <div class="d-flex align-start gap-2 mb-1">
+    <div class="d-flex align-start gap-2 mb-2">
         <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Filled">
             FWS @Link.FwsAction.Code
         </MudChip>
-        <MudText Typo="Typo.body2">@Link.FwsAction.Name</MudText>
+        <MudText Typo="Typo.body1">@Link.FwsAction.Name</MudText>
     </div>
     @if (!string.IsNullOrEmpty(Link.Justification))
     {
         <MudDivider Class="my-2" />
-        <MudText Typo="Typo.caption" Color="Color.Secondary">
+        <MudText Typo="Typo.body2">
             @Link.Justification
         </MudText>
     }

--- a/src/FaunaFinder.Client/Components/SpeciesExpansionPanel.razor
+++ b/src/FaunaFinder.Client/Components/SpeciesExpansionPanel.razor
@@ -5,10 +5,10 @@
                    Class="mb-2">
     <TitleContent>
         <div class="d-flex flex-column">
-            <MudText Typo="@TitleTypo" Color="Color.Primary" Class="font-semibold">
+            <MudText Typo="Typo.subtitle1" Class="font-semibold">
                 @L.GetLocalizedValue(Species.CommonName)
             </MudText>
-            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1 italic">
+            <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mt-1 italic">
                 @Species.ScientificName
             </MudText>
         </div>


### PR DESCRIPTION
Closes #185

## Summary
- Change species name from green (Color.Primary) to theme-aware default color (white in dark mode, dark in light mode)
- Increase text sizes throughout the species expansion panel and conservation link cards
- Add more padding to conservation link cards for better visual spacing

## Test plan
- [ ] Click a municipality on the map, then expand a species
- [ ] Verify species name is now theme-aware (not green)
- [ ] Verify text is larger and more readable
- [ ] Test in both dark and light modes
- [ ] Verify mobile responsiveness is maintained