### PR TITLE
Feat: Add View Location button to municipality detail page

### DIFF
--- a/src/FaunaFinder.Client/Pages/Home.razor
+++ b/src/FaunaFinder.Client/Pages/Home.razor
@@ -609,6 +609,9 @@
     [SupplyParameterFromQuery]
     public bool RestoreNearMe { get; set; }
 
+    [SupplyParameterFromQuery]
+    public string? MunicipalityId { get; set; }
+
     private MunicipalityForListDto? selectedMunicipality;
     private string? clickedMunicipalityName;
     private IReadOnlyList<SpeciesForListDto> species = [];
@@ -824,7 +827,36 @@
             {
                 await RestoreNearbySpeciesState();
             }
+            // Check if we need to focus on a specific municipality
+            else if (!string.IsNullOrEmpty(MunicipalityId))
+            {
+                await FocusOnMunicipalityFromParam();
+            }
         }
+    }
+
+    private async Task FocusOnMunicipalityFromParam()
+    {
+        if (string.IsNullOrEmpty(MunicipalityId))
+            return;
+
+        // GeoJsonId is in format "72XXX" where XXX is the county code
+        var countyCode = MunicipalityId.Length > 2 ? MunicipalityId.Substring(2) : MunicipalityId;
+
+        // Find the municipality to get its name
+        var municipality = municipalities?.FirstOrDefault(m => m.GeoJsonId == MunicipalityId);
+
+        if (municipality != null)
+        {
+            // Highlight and focus on the municipality
+            await MapService.HighlightMunicipalityAsync(countyCode);
+            await MapService.FocusOnMunicipalityAsync(countyCode);
+
+            // Also load and show the species for this municipality
+            await OnMunicipalityClick(municipality.GeoJsonId, municipality.Name);
+        }
+
+        StateHasChanged();
     }
 
     private async void OnDarkModeChanged()

--- a/src/FaunaFinder.Client/Pages/PuebloDetail.razor
+++ b/src/FaunaFinder.Client/Pages/PuebloDetail.razor
@@ -34,12 +34,22 @@
     else
     {
         <MudPaper Elevation="2" Class="pa-4 mb-6">
-            <MudText Typo="Typo.h4" Color="Color.Primary" GutterBottom="true">@municipality.Name</MudText>
-            <div class="d-flex align-center">
-                <MudIcon Icon="@Icons.Material.Filled.Pets" Size="Size.Medium" Color="Color.Secondary" Class="mr-2" />
-                <MudText Typo="Typo.h6" Color="Color.Secondary">
-                    @municipality.SpeciesCount @L["Pueblos_Species"]
-                </MudText>
+            <div class="d-flex justify-space-between align-start flex-wrap gap-2">
+                <div>
+                    <MudText Typo="Typo.h4" Color="Color.Primary" GutterBottom="true">@municipality.Name</MudText>
+                    <div class="d-flex align-center">
+                        <MudIcon Icon="@Icons.Material.Filled.Pets" Size="Size.Medium" Color="Color.Secondary" Class="mr-2" />
+                        <MudText Typo="Typo.h6" Color="Color.Secondary">
+                            @municipality.SpeciesCount @L["Pueblos_Species"]
+                        </MudText>
+                    </div>
+                </div>
+                <MudButton Variant="Variant.Outlined"
+                           Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Map"
+                           OnClick="ViewOnMap">
+                    @L["PuebloDetail_ViewLocation"]
+                </MudButton>
             </div>
         </MudPaper>
     }
@@ -215,5 +225,13 @@
     private void NavigateToSpecies(int speciesId)
     {
         NavigationManager.NavigateTo($"/species/{speciesId}?returnUrl=/pueblos/{Id}");
+    }
+
+    private void ViewOnMap()
+    {
+        if (municipality != null)
+        {
+            NavigationManager.NavigateTo($"/?municipalityId={municipality.GeoJsonId}");
+        }
     }
 }

--- a/src/FaunaFinder.Client/Services/Localization/Translations.cs
+++ b/src/FaunaFinder.Client/Services/Localization/Translations.cs
@@ -82,6 +82,7 @@ public static class Translations
             ["PuebloDetail_NoSpeciesData"] = "No species data available for this municipality.",
             ["PuebloDetail_NoConservationLinks"] =
                 "No conservation links available for this species.",
+            ["PuebloDetail_ViewLocation"] = "View on Map",
 
             // About Page
             ["About_Title"] = "About FaunaFinder",
@@ -443,6 +444,7 @@ public static class Translations
                 "No hay datos de especies disponibles para este municipio.",
             ["PuebloDetail_NoConservationLinks"] =
                 "No hay enlaces de conservación disponibles para esta especie.",
+            ["PuebloDetail_ViewLocation"] = "Ver en Mapa",
 
             // About Page
             ["About_Title"] = "Acerca de FaunaFinder",

--- a/src/FaunaFinder.Client/Services/Map/IMapService.cs
+++ b/src/FaunaFinder.Client/Services/Map/IMapService.cs
@@ -31,6 +31,10 @@ public interface IMapService
     Task EnableDrawModeAsync();
     Task DisableDrawModeAsync();
     Task ClearDrawnCircleAsync();
+
+    // Municipality highlight methods
+    Task HighlightMunicipalityAsync(string countyCode);
+    Task FocusOnMunicipalityAsync(string countyCode);
 }
 
 public record SpeciesLocationData(

--- a/src/FaunaFinder.Client/Services/Map/MapService.cs
+++ b/src/FaunaFinder.Client/Services/Map/MapService.cs
@@ -166,4 +166,14 @@ public sealed class MapService : IMapService
     {
         await _js.InvokeVoidAsync("leafletInterop.clearDrawnCircle");
     }
+
+    public async Task HighlightMunicipalityAsync(string countyCode)
+    {
+        await _js.InvokeVoidAsync("leafletInterop.highlightMunicipality", countyCode);
+    }
+
+    public async Task FocusOnMunicipalityAsync(string countyCode)
+    {
+        await _js.InvokeVoidAsync("leafletInterop.focusOnMunicipality", countyCode);
+    }
 }

--- a/src/FaunaFinder.Server/Services/Localization/Translations.cs
+++ b/src/FaunaFinder.Server/Services/Localization/Translations.cs
@@ -76,6 +76,7 @@ public static class Translations
             ["PuebloDetail_NoSpeciesData"] = "No species data available for this municipality.",
             ["PuebloDetail_NoConservationLinks"] =
                 "No conservation links available for this species.",
+            ["PuebloDetail_ViewLocation"] = "View on Map",
 
             // About Page
             ["About_Title"] = "About FaunaFinder",
@@ -217,6 +218,7 @@ public static class Translations
                 "No hay datos de especies disponibles para este municipio.",
             ["PuebloDetail_NoConservationLinks"] =
                 "No hay enlaces de conservación disponibles para esta especie.",
+            ["PuebloDetail_ViewLocation"] = "Ver en Mapa",
 
             // About Page
             ["About_Title"] = "Acerca de FaunaFinder",

--- a/src/FaunaFinder.Server/wwwroot/js/leafletInterop.js
+++ b/src/FaunaFinder.Server/wwwroot/js/leafletInterop.js
@@ -511,6 +511,21 @@ window.leafletInterop = {
             }
         });
     },
+    focusOnMunicipality(county) {
+        if (!this.geojsonLayer)
+            return;
+        this.geojsonLayer.eachLayer((layer) => {
+            const geoLayer = layer;
+            const feature = geoLayer.feature;
+            if (feature && feature.properties && feature.properties.COUNTY === county) {
+                const bounds = geoLayer.getBounds();
+                this.map.flyToBounds(bounds, {
+                    padding: [50, 50],
+                    duration: 0.8
+                });
+            }
+        });
+    },
     showSpeciesLocations(speciesName, locations) {
         this.clearSpeciesLocations();
         if (!locations || locations.length === 0)

--- a/src/FaunaFinder.Server/wwwroot/js/leafletInterop.ts
+++ b/src/FaunaFinder.Server/wwwroot/js/leafletInterop.ts
@@ -117,6 +117,7 @@ interface Window {
 interface GeoJSONLayerWithFeature extends L.Layer {
     feature?: MunicipalityFeature;
     setStyle(style: L.PathOptions): this;
+    getBounds(): L.LatLngBounds;
 }
 
 // ============================================================================
@@ -173,6 +174,7 @@ interface LeafletInterop {
     highlightFeature(e: L.LeafletMouseEvent): void;
     resetHighlight(e: L.LeafletMouseEvent): void;
     highlightMunicipality(county: string): void;
+    focusOnMunicipality(county: string): void;
     showSpeciesLocations(speciesName: string, locations: SpeciesLocation[]): void;
     clearSpeciesLocations(): void;
     focusOnLocation(index: number): void;
@@ -774,6 +776,23 @@ window.leafletInterop = {
                 } else {
                     self.geojsonLayer!.resetStyle(layer as L.Path);
                 }
+            }
+        });
+    },
+
+    focusOnMunicipality(county: string): void {
+        if (!this.geojsonLayer) return;
+
+        this.geojsonLayer.eachLayer((layer: L.Layer) => {
+            const geoLayer = layer as GeoJSONLayerWithFeature;
+            const feature = geoLayer.feature;
+
+            if (feature && feature.properties && feature.properties.COUNTY === county) {
+                const bounds = geoLayer.getBounds();
+                this.map!.flyToBounds(bounds, {
+                    padding: [50, 50],
+                    duration: 0.8
+                });
             }
         });
     },


### PR DESCRIPTION
## Summary
- Adds a "View on Map" button to the municipality detail page
- Clicking the button navigates to the map page with the municipality highlighted and zoomed in
- The municipality's species are automatically loaded in the sidebar

## Changes
- **PuebloDetail.razor**: Added "View on Map" button that navigates to `/?municipalityId={GeoJsonId}`
- **Home.razor**: Added `MunicipalityId` query parameter handling to highlight and focus on municipality
- **IMapService.cs / MapService.cs**: Added `HighlightMunicipalityAsync` and `FocusOnMunicipalityAsync` methods
- **leafletInterop.js**: Added `focusOnMunicipality` function to zoom to municipality bounds
- **Translations.cs**: Added "View on Map" / "Ver en Mapa" translations

## Test plan
- [ ] Navigate to a municipality detail page (e.g., `/pueblos/1`)
- [ ] Click the "View on Map" button
- [ ] Verify the map zooms to and highlights the municipality
- [ ] Verify the species sidebar opens with the municipality's species

Closes #209