### PR TITLE
Feat: Add PDF export button to species detail page

### DIFF
--- a/src/FaunaFinder.Client/Pages/SpeciesDetail.razor
+++ b/src/FaunaFinder.Client/Pages/SpeciesDetail.razor
@@ -1,6 +1,9 @@
 @page "/species/{Id:int}"
 @using BlazingSingularity.Commands
+@using FaunaFinder.Client.Services.Map
 @inject ISpeciesHttpClient SpeciesHttpClient
+@inject IExportHttpClient ExportHttpClient
+@inject IMapService MapService
 @inject NavigationManager NavigationManager
 @inject IAppLocalizer L
 
@@ -79,16 +82,28 @@
                             @L["SpeciesDetail_FoundIn", species.Municipalities.Count, species.Municipalities.Count == 1 ? L["Species_Municipality"] : L["Species_Municipalities"]]
                         </MudText>
                     </div>
-                    @if (species.Locations.Count > 0)
-                    {
-                        <MudButton Variant="Variant.Filled"
+                    <div class="d-flex flex-wrap gap-2 mt-4">
+                        @if (species.Locations.Count > 0)
+                        {
+                            <MudButton Variant="Variant.Filled"
+                                       Color="Color.Primary"
+                                       StartIcon="@Icons.Material.Filled.Map"
+                                       OnClick="ViewLocations">
+                                @L["SpeciesDetail_ViewLocations"]
+                            </MudButton>
+                        }
+                        <MudButton Variant="Variant.Outlined"
                                    Color="Color.Primary"
-                                   StartIcon="@Icons.Material.Filled.Map"
-                                   OnClick="ViewLocations"
-                                   Class="mt-4">
-                            @L["SpeciesDetail_ViewLocations"]
+                                   StartIcon="@Icons.Material.Filled.PictureAsPdf"
+                                   OnClick="() => DownloadPdfCommand.ExecuteAsync()"
+                                   Disabled="DownloadPdfCommand.IsLoading">
+                            @if (DownloadPdfCommand.IsLoading)
+                            {
+                                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                            }
+                            @L["Export_PDF"]
                         </MudButton>
-                    }
+                    </div>
                 </MudItem>
             </MudGrid>
         </MudPaper>
@@ -377,6 +392,18 @@
     private void ViewLocations()
     {
         NavigationManager.NavigateTo($"/?speciesId={Id}");
+    }
+
+    [RelayCommand]
+    private async Task DownloadPdf()
+    {
+        if (species == null)
+            return;
+
+        var pdfBytes = await ExportHttpClient.ExportSpeciesPdfAsync(species.Id);
+        var commonName = L.GetLocalizedValue(species.CommonName);
+        var fileName = $"{commonName.Replace(" ", "_")}_Report.pdf";
+        await MapService.DownloadFileAsync(pdfBytes, fileName, "application/pdf");
     }
 
     private string GetProfileImageUrl()

--- a/src/FaunaFinder.Server/Endpoints/ExportEndpoints.cs
+++ b/src/FaunaFinder.Server/Endpoints/ExportEndpoints.cs
@@ -11,6 +11,7 @@ public static class ExportEndpoints
 
         group.MapGet("/municipality/{municipalityId:int}/pdf", ExportMunicipalityPdf).WithName("ExportMunicipalityPdf");
         group.MapGet("/municipality/{municipalityId:int}/csv", ExportMunicipalityCsv).WithName("ExportMunicipalityCsv");
+        group.MapGet("/species/{speciesId:int}/pdf", ExportSpeciesPdf).WithName("ExportSpeciesPdf");
     }
 
     private static async Task<IResult> ExportMunicipalityPdf(
@@ -63,5 +64,22 @@ public static class ExportEndpoints
         var fileName = $"{municipality.Name.Replace(" ", "_")}_Species_Report.csv";
 
         return Results.File(csvBytes, "text/csv", fileName);
+    }
+
+    private static async Task<IResult> ExportSpeciesPdf(
+        int speciesId,
+        ISpeciesRepository speciesRepository,
+        ISpeciesReportService reportService,
+        CancellationToken ct)
+    {
+        var species = await speciesRepository.GetSpeciesDetailAsync(speciesId, ct);
+        if (species is null)
+            return Results.NotFound();
+
+        var pdfBytes = reportService.GeneratePdfReport(species);
+        var commonName = species.CommonName.FirstOrDefault()?.Value ?? species.ScientificName;
+        var fileName = $"{commonName.Replace(" ", "_")}_Report.pdf";
+
+        return Results.File(pdfBytes, "application/pdf", fileName);
     }
 }

--- a/src/FaunaFinder.Server/Program.cs
+++ b/src/FaunaFinder.Server/Program.cs
@@ -20,6 +20,7 @@ builder.Services.AddRazorComponents().AddInteractiveWebAssemblyComponents();
 
 builder.Services.AddScoped<IAppLocalizer, AppLocalizer>();
 builder.Services.AddScoped<IMunicipalityReportService, MunicipalityReportService>();
+builder.Services.AddScoped<ISpeciesReportService, SpeciesReportService>();
 
 QuestPDF.Settings.License = LicenseType.Community;
 

--- a/src/FaunaFinder.Server/Services/Export/ISpeciesReportService.cs
+++ b/src/FaunaFinder.Server/Services/Export/ISpeciesReportService.cs
@@ -1,0 +1,8 @@
+using FaunaFinder.Wildlife.Contracts.Dtos;
+
+namespace FaunaFinder.Server.Services.Export;
+
+public interface ISpeciesReportService
+{
+    byte[] GeneratePdfReport(SpeciesForDetailDto species);
+}

--- a/src/FaunaFinder.Server/Services/Export/SpeciesReportService.cs
+++ b/src/FaunaFinder.Server/Services/Export/SpeciesReportService.cs
@@ -1,0 +1,211 @@
+using System.Globalization;
+using FaunaFinder.Server.Services.Localization;
+using FaunaFinder.Wildlife.Contracts.Dtos;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace FaunaFinder.Server.Services.Export;
+
+public class SpeciesReportService(IAppLocalizer localizer) : ISpeciesReportService
+{
+    private readonly IAppLocalizer _localizer = localizer;
+
+    public byte[] GeneratePdfReport(SpeciesForDetailDto species)
+    {
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.Letter);
+                page.Margin(40);
+                page.DefaultTextStyle(x => x.FontSize(10));
+
+                page.Content().Element(c => ComposeContent(c, species));
+                page.Footer().Element(ComposeFooter);
+            });
+        });
+
+        return document.GeneratePdf();
+    }
+
+    private void ComposeContent(IContainer container, SpeciesForDetailDto species)
+    {
+        container.Column(column =>
+        {
+            // Title section (only appears once at the top)
+            column
+                .Item()
+                .Row(row =>
+                {
+                    row.RelativeItem()
+                        .Column(col =>
+                        {
+                            col.Item()
+                                .Text("FaunaFinder")
+                                .Bold()
+                                .FontSize(20)
+                                .FontColor(Colors.Green.Darken2);
+                            col.Item()
+                                .Text("Species Conservation Report")
+                                .FontSize(12)
+                                .FontColor(Colors.Grey.Darken1);
+                        });
+
+                    row.ConstantItem(120)
+                        .AlignRight()
+                        .Column(col =>
+                        {
+                            col.Item()
+                                .Text(
+                                    DateTime.Now.ToString(
+                                        "MMMM d, yyyy",
+                                        CultureInfo.InvariantCulture
+                                    )
+                                )
+                                .FontSize(9)
+                                .FontColor(Colors.Grey.Darken1);
+                        });
+                });
+
+            column.Item().PaddingTop(10).BorderBottom(1).BorderColor(Colors.Green.Darken2);
+
+            // Species name
+            column
+                .Item()
+                .PaddingTop(15)
+                .Text(_localizer.GetLocalizedValue(species.CommonName))
+                .Bold()
+                .FontSize(16);
+
+            column
+                .Item()
+                .PaddingTop(3)
+                .Text(species.ScientificName)
+                .Italic()
+                .FontSize(12)
+                .FontColor(Colors.Grey.Darken1);
+
+            column.Item().PaddingTop(15);
+
+            // Municipalities section
+            if (species.Municipalities.Count > 0)
+            {
+                column
+                    .Item()
+                    .Text("Municipalities")
+                    .FontSize(12)
+                    .Bold()
+                    .FontColor(Colors.Green.Darken3);
+
+                column.Item().PaddingTop(5);
+
+                column
+                    .Item()
+                    .Text(string.Join(", ", species.Municipalities.Select(m => m.Name)))
+                    .FontSize(10)
+                    .FontColor(Colors.Grey.Darken2);
+
+                column.Item().PaddingTop(15);
+            }
+
+            // Conservation Links section
+            if (species.FwsLinks.Count > 0)
+            {
+                column
+                    .Item()
+                    .Text($"Conservation Links ({species.FwsLinks.Count})")
+                    .FontSize(12)
+                    .Bold()
+                    .FontColor(Colors.Green.Darken3);
+
+                column.Item().PaddingTop(10);
+
+                foreach (var link in species.FwsLinks)
+                {
+                    column.Item().Element(c => ComposeConservationLink(c, link));
+                }
+            }
+            else
+            {
+                column
+                    .Item()
+                    .Text("No conservation links available for this species.")
+                    .FontSize(10)
+                    .FontColor(Colors.Grey.Darken1);
+            }
+        });
+    }
+
+    private void ComposeConservationLink(IContainer container, FwsLinkDto link)
+    {
+        container
+            .PaddingBottom(10)
+            .Border(1)
+            .BorderColor(Colors.Grey.Lighten2)
+            .Background(Colors.Grey.Lighten5)
+            .Padding(10)
+            .Column(column =>
+            {
+                column
+                    .Item()
+                    .Row(row =>
+                    {
+                        row.ConstantItem(70)
+                            .Text($"NRCS {link.NrcsPractice.Code}")
+                            .FontSize(9)
+                            .Bold()
+                            .FontColor(Colors.Blue.Darken2);
+                        row.RelativeItem().Text(link.NrcsPractice.Name).FontSize(10);
+                    });
+
+                column
+                    .Item()
+                    .PaddingTop(4)
+                    .Row(row =>
+                    {
+                        row.ConstantItem(70)
+                            .Text($"FWS {link.FwsAction.Code}")
+                            .FontSize(9)
+                            .Bold()
+                            .FontColor(Colors.Orange.Darken2);
+                        row.RelativeItem().Text(link.FwsAction.Name).FontSize(10);
+                    });
+
+                if (!string.IsNullOrEmpty(link.Justification))
+                {
+                    column
+                        .Item()
+                        .PaddingTop(6)
+                        .Text(link.Justification)
+                        .FontSize(9)
+                        .FontColor(Colors.Grey.Darken1);
+                }
+            });
+    }
+
+    private void ComposeFooter(IContainer container)
+    {
+        container
+            .BorderTop(1)
+            .BorderColor(Colors.Grey.Lighten2)
+            .PaddingTop(5)
+            .Row(row =>
+            {
+                row.RelativeItem()
+                    .Text("Generated by FaunaFinder - faunafinder.pr")
+                    .FontSize(8)
+                    .FontColor(Colors.Grey.Darken1);
+
+                row.RelativeItem()
+                    .AlignRight()
+                    .Text(text =>
+                    {
+                        text.Span("Page ").FontSize(8).FontColor(Colors.Grey.Darken1);
+                        text.CurrentPageNumber().FontSize(8).FontColor(Colors.Grey.Darken1);
+                        text.Span(" of ").FontSize(8).FontColor(Colors.Grey.Darken1);
+                        text.TotalPages().FontSize(8).FontColor(Colors.Grey.Darken1);
+                    });
+            });
+    }
+}

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/ExportHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/ExportHttpClient.cs
@@ -35,4 +35,15 @@ public sealed class ExportHttpClient(HttpClient httpClient) : IExportHttpClient
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsByteArrayAsync(cancellationToken);
     }
+
+    public async Task<byte[]> ExportSpeciesPdfAsync(
+        int speciesId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var url = $"/api/export/species/{speciesId}/pdf";
+        var response = await httpClient.GetAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsByteArrayAsync(cancellationToken);
+    }
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IExportHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IExportHttpClient.cs
@@ -13,4 +13,9 @@ public interface IExportHttpClient
         IEnumerable<int>? speciesIds = null,
         CancellationToken cancellationToken = default
     );
+
+    Task<byte[]> ExportSpeciesPdfAsync(
+        int speciesId,
+        CancellationToken cancellationToken = default
+    );
 }


### PR DESCRIPTION
## Summary
- Add PDF download button to species detail page
- Generate species conservation reports using QuestPDF
- Include species name, municipalities, and conservation links in the PDF

## Test plan
- [ ] Navigate to a species detail page
- [ ] Click the "Download PDF" button
- [ ] Verify PDF downloads with correct species information
- [ ] Verify header/title only appears on first page

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)