### PR TITLE
Feat: Implement keyset pagination with IAsyncEnumerable streaming

### DIFF
--- a/src/Common/FaunaFinder.Pagination.Contracts/FaunaFinder.Pagination.Contracts.csproj
+++ b/src/Common/FaunaFinder.Pagination.Contracts/FaunaFinder.Pagination.Contracts.csproj
@@ -4,4 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
+  </ItemGroup>
 </Project>

--- a/src/Common/FaunaFinder.Pagination.Contracts/KeysetPagination.cs
+++ b/src/Common/FaunaFinder.Pagination.Contracts/KeysetPagination.cs
@@ -1,0 +1,10 @@
+namespace FaunaFinder.Pagination.Contracts;
+
+/// <summary>
+/// Base record for keyset (cursor-based) pagination with a strongly-typed cursor.
+/// </summary>
+/// <typeparam name="TKey">The type of the cursor key (typically int for entity IDs)</typeparam>
+public record KeysetPagination<TKey>(
+    int PageSize = 20,
+    TKey? Cursor = default
+) where TKey : struct;

--- a/src/Common/FaunaFinder.Pagination.Contracts/KeysetPaginationValidator.cs
+++ b/src/Common/FaunaFinder.Pagination.Contracts/KeysetPaginationValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace FaunaFinder.Pagination.Contracts;
+
+/// <summary>
+/// Reusable validator for keyset pagination parameters.
+/// Ensures PageSize is within acceptable bounds.
+/// </summary>
+public class KeysetPaginationValidator<TKey> : AbstractValidator<KeysetPagination<TKey>>
+    where TKey : struct
+{
+    public KeysetPaginationValidator(int maxPageSize = 100)
+    {
+        RuleFor(x => x.PageSize)
+            .InclusiveBetween(1, maxPageSize)
+            .WithMessage($"PageSize must be between 1 and {maxPageSize}");
+    }
+}

--- a/src/FaunaFinder.Client/Pages/Pueblos.razor
+++ b/src/FaunaFinder.Client/Pages/Pueblos.razor
@@ -76,7 +76,7 @@
 @code {
     private List<MunicipalityCardDto> municipalities = new();
     private string searchTerm = string.Empty;
-    private string? nextCursor;
+    private int? cursor;
     private bool hasMore = true;
     private bool isInitialLoading = true;
     private bool isLoadingMore = false;
@@ -119,12 +119,27 @@
         isLoadingMore = true;
         StateHasChanged();
 
-        var request = new CursorPageParameter(nextCursor, PageSize, string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm);
-        var page = await MunicipalityHttpClient.GetMunicipalitiesCursorPageAsync(request);
+        var parameters = new MunicipalityParameters(
+            PageSize: PageSize,
+            Cursor: cursor,
+            Search: string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm
+        );
 
-        municipalities.AddRange(page.Items);
-        nextCursor = page.NextCursor;
-        hasMore = page.HasMore;
+        var items = new List<MunicipalityCardDto>();
+        await foreach (var item in MunicipalityHttpClient.GetMunicipalityCardsAsync(parameters))
+        {
+            items.Add(item);
+        }
+
+        // Server returns PageSize+1 items; if we got more than PageSize, there's more data
+        hasMore = items.Count > PageSize;
+        if (hasMore)
+        {
+            items.RemoveAt(items.Count - 1);
+        }
+
+        municipalities.AddRange(items);
+        cursor = items.Count > 0 ? items[^1].Id : null;
 
         isLoadingMore = false;
         StateHasChanged();
@@ -134,7 +149,7 @@
     {
         // Reset state for new search
         municipalities.Clear();
-        nextCursor = null;
+        cursor = null;
         hasMore = true;
         isInitialLoading = true;
         isObserverInitialized = false;

--- a/src/FaunaFinder.Client/Pages/Species.razor
+++ b/src/FaunaFinder.Client/Pages/Species.razor
@@ -104,7 +104,7 @@
     private List<SpeciesCategoryDto> categories = new();
     private HashSet<int> selectedCategoryIds = new();
     private string searchTerm = string.Empty;
-    private string? nextCursor;
+    private int? cursor;
     private bool hasMore = true;
     private bool isInitialLoading = true;
     private bool isLoadingMore = false;
@@ -171,17 +171,28 @@
         isLoadingMore = true;
         StateHasChanged();
 
-        var request = new CursorPageParameter(
-            nextCursor,
-            PageSize,
-            string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm,
-            GetCategoryIdsString()
+        var parameters = new SpeciesParameters(
+            PageSize: PageSize,
+            Cursor: cursor,
+            Search: string.IsNullOrWhiteSpace(searchTerm) ? null : searchTerm,
+            CategoryIds: GetCategoryIdsString()
         );
-        var page = await SpeciesHttpClient.GetSpeciesCursorPageAsync(request);
 
-        species.AddRange(page.Items);
-        nextCursor = page.NextCursor;
-        hasMore = page.HasMore;
+        var items = new List<SpeciesForSearchDto>();
+        await foreach (var item in SpeciesHttpClient.GetSpeciesAsync(parameters))
+        {
+            items.Add(item);
+        }
+
+        // Server returns PageSize+1 items; if we got more than PageSize, there's more data
+        hasMore = items.Count > PageSize;
+        if (hasMore)
+        {
+            items.RemoveAt(items.Count - 1);
+        }
+
+        species.AddRange(items);
+        cursor = items.Count > 0 ? items[^1].Id : null;
 
         isLoadingMore = false;
         StateHasChanged();
@@ -191,7 +202,7 @@
     {
         // Reset state for new search
         species.Clear();
-        nextCursor = null;
+        cursor = null;
         hasMore = true;
         isInitialLoading = true;
         isObserverInitialized = false;

--- a/src/FaunaFinder.Server/Endpoints/MunicipalityEndpoints.cs
+++ b/src/FaunaFinder.Server/Endpoints/MunicipalityEndpoints.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using FaunaFinder.Pagination.Contracts;
 using FaunaFinder.Wildlife.Contracts.Dtos;
 using FaunaFinder.Wildlife.Contracts.Parameters;
 using FaunaFinder.Wildlife.DataAccess.Interfaces;
@@ -21,7 +20,6 @@ public static class MunicipalityEndpoints
         group.MapGet("/cards", GetMunicipalityCards).WithName("GetMunicipalityCards");
         group.MapGet("/count", GetMunicipalitiesCount).WithName("GetMunicipalitiesCount");
         group.MapGet("/geojson", GetMunicipalitiesGeoJson).WithName("GetMunicipalitiesGeoJson");
-        group.MapGet("/cursor", GetMunicipalitiesCursor).WithName("GetMunicipalitiesCursor");
     }
 
     private static async Task<Ok<IReadOnlyList<MunicipalityForListDto>>> GetAllMunicipalities(
@@ -41,13 +39,12 @@ public static class MunicipalityEndpoints
         return municipality is not null ? TypedResults.Ok(municipality) : TypedResults.NotFound();
     }
 
-    private static async Task<Ok<IReadOnlyList<MunicipalityCardDto>>> GetMunicipalityCards(
+    private static IAsyncEnumerable<MunicipalityCardDto> GetMunicipalityCards(
         [AsParameters] MunicipalityParameters parameters,
         IMunicipalityRepository repository,
         CancellationToken ct)
     {
-        var municipalities = await repository.GetMunicipalitiesWithSpeciesCountAsync(parameters, ct);
-        return TypedResults.Ok(municipalities);
+        return repository.GetMunicipalitiesWithSpeciesCountAsync(parameters, ct);
     }
 
     private static async Task<Ok<int>> GetMunicipalitiesCount(
@@ -88,14 +85,5 @@ public static class MunicipalityEndpoints
         jsonOptions.Converters.Add(new GeoJsonConverterFactory());
 
         return Results.Json(featureCollection, jsonOptions, contentType: "application/geo+json");
-    }
-
-    private static async Task<Ok<CursorPage<MunicipalityCardDto>>> GetMunicipalitiesCursor(
-        [AsParameters] CursorPageParameter parameters,
-        IMunicipalityRepository repository,
-        CancellationToken ct)
-    {
-        var page = await repository.GetMunicipalitiesCursorPageAsync(parameters, ct);
-        return TypedResults.Ok(page);
     }
 }

--- a/src/FaunaFinder.Server/Endpoints/SpeciesEndpoints.cs
+++ b/src/FaunaFinder.Server/Endpoints/SpeciesEndpoints.cs
@@ -1,4 +1,3 @@
-using FaunaFinder.Pagination.Contracts;
 using FaunaFinder.Wildlife.Contracts.Dtos;
 using FaunaFinder.Wildlife.Contracts.Parameters;
 using FaunaFinder.Wildlife.DataAccess.Interfaces;
@@ -17,17 +16,15 @@ public static class SpeciesEndpoints
         group.MapGet("/by-municipality/{municipalityId:int}", GetSpeciesByMunicipality).WithName("GetSpeciesByMunicipality");
         group.MapGet("/count", GetSpeciesCount).WithName("GetSpeciesCount");
         group.MapGet("/nearby", GetSpeciesNearby).WithName("GetSpeciesNearby");
-        group.MapGet("/cursor", GetSpeciesCursor).WithName("GetSpeciesCursor");
         group.MapGet("/categories", GetCategories).WithName("GetCategories");
     }
 
-    private static async Task<Ok<IReadOnlyList<SpeciesForSearchDto>>> GetSpecies(
+    private static IAsyncEnumerable<SpeciesForSearchDto> GetSpecies(
         [AsParameters] SpeciesParameters parameters,
         ISpeciesRepository repository,
         CancellationToken ct)
     {
-        var species = await repository.GetSpeciesAsync(parameters, ct);
-        return TypedResults.Ok(species);
+        return repository.GetSpeciesAsync(parameters, ct);
     }
 
     private static async Task<Results<Ok<SpeciesForDetailDto>, NotFound>> GetSpeciesDetail(
@@ -68,15 +65,6 @@ public static class SpeciesEndpoints
             parameters.RadiusMeters,
             ct);
         return TypedResults.Ok(species);
-    }
-
-    private static async Task<Ok<CursorPage<SpeciesForSearchDto>>> GetSpeciesCursor(
-        [AsParameters] CursorPageParameter parameters,
-        ISpeciesRepository repository,
-        CancellationToken ct)
-    {
-        var page = await repository.GetSpeciesCursorPageAsync(parameters, ct);
-        return TypedResults.Ok(page);
     }
 
     private static async Task<Ok<IReadOnlyList<SpeciesCategoryDto>>> GetCategories(

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IMunicipalityHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IMunicipalityHttpClient.cs
@@ -1,4 +1,3 @@
-using FaunaFinder.Pagination.Contracts;
 using FaunaFinder.Wildlife.Contracts.Dtos;
 using FaunaFinder.Wildlife.Contracts.Parameters;
 
@@ -15,18 +14,13 @@ public interface IMunicipalityHttpClient
         CancellationToken cancellationToken = default
     );
 
-    Task<IReadOnlyList<MunicipalityCardDto>> GetMunicipalitiesWithSpeciesCountAsync(
+    IAsyncEnumerable<MunicipalityCardDto> GetMunicipalityCardsAsync(
         MunicipalityParameters parameters,
         CancellationToken cancellationToken = default
     );
 
     Task<int> GetTotalMunicipalitiesCountAsync(
         string? search = null,
-        CancellationToken cancellationToken = default
-    );
-
-    Task<CursorPage<MunicipalityCardDto>> GetMunicipalitiesCursorPageAsync(
-        CursorPageParameter request,
         CancellationToken cancellationToken = default
     );
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/ISpeciesHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/ISpeciesHttpClient.cs
@@ -1,4 +1,3 @@
-using FaunaFinder.Pagination.Contracts;
 using FaunaFinder.Wildlife.Contracts.Dtos;
 using FaunaFinder.Wildlife.Contracts.Parameters;
 
@@ -16,7 +15,7 @@ public interface ISpeciesHttpClient
         CancellationToken cancellationToken = default
     );
 
-    Task<IReadOnlyList<SpeciesForSearchDto>> GetSpeciesAsync(
+    IAsyncEnumerable<SpeciesForSearchDto> GetSpeciesAsync(
         SpeciesParameters parameters,
         CancellationToken cancellationToken = default
     );
@@ -30,11 +29,6 @@ public interface ISpeciesHttpClient
         double latitude,
         double longitude,
         double radiusMeters,
-        CancellationToken cancellationToken = default
-    );
-
-    Task<CursorPage<SpeciesForSearchDto>> GetSpeciesCursorPageAsync(
-        CursorPageParameter request,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/MunicipalityHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/MunicipalityHttpClient.cs
@@ -1,5 +1,4 @@
 using System.Net.Http.Json;
-using FaunaFinder.Pagination.Contracts;
 using FaunaFinder.Wildlife.Contracts.Dtos;
 using FaunaFinder.Wildlife.Contracts.Parameters;
 
@@ -29,17 +28,16 @@ public sealed class MunicipalityHttpClient(HttpClient httpClient) : IMunicipalit
         );
     }
 
-    public async Task<IReadOnlyList<MunicipalityCardDto>> GetMunicipalitiesWithSpeciesCountAsync(
+    public IAsyncEnumerable<MunicipalityCardDto> GetMunicipalityCardsAsync(
         MunicipalityParameters parameters,
         CancellationToken cancellationToken = default
     )
     {
         var queryString = BuildMunicipalityQueryString(parameters);
-        var result = await httpClient.GetFromJsonAsync<IReadOnlyList<MunicipalityCardDto>>(
+        return httpClient.GetFromJsonAsAsyncEnumerable<MunicipalityCardDto>(
             $"api/municipalities/cards{queryString}",
             cancellationToken
-        );
-        return result ?? [];
+        )!;
     }
 
     public async Task<int> GetTotalMunicipalitiesCountAsync(
@@ -56,45 +54,16 @@ public sealed class MunicipalityHttpClient(HttpClient httpClient) : IMunicipalit
 
     private static string BuildMunicipalityQueryString(MunicipalityParameters parameters)
     {
-        var queryParams = new List<string>
+        var queryParams = new List<string> { $"pageSize={parameters.PageSize}" };
+
+        if (parameters.Cursor.HasValue)
         {
-            $"pageSize={parameters.PageSize}",
-            $"page={parameters.Page}",
-        };
+            queryParams.Add($"cursor={parameters.Cursor.Value}");
+        }
 
         if (!string.IsNullOrEmpty(parameters.Search))
         {
             queryParams.Add($"search={Uri.EscapeDataString(parameters.Search)}");
-        }
-
-        return "?" + string.Join("&", queryParams);
-    }
-
-    public async Task<CursorPage<MunicipalityCardDto>> GetMunicipalitiesCursorPageAsync(
-        CursorPageParameter request,
-        CancellationToken cancellationToken = default
-    )
-    {
-        var queryString = BuildCursorQueryString(request);
-        var result = await httpClient.GetFromJsonAsync<CursorPage<MunicipalityCardDto>>(
-            $"api/municipalities/cursor{queryString}",
-            cancellationToken
-        );
-        return result ?? new CursorPage<MunicipalityCardDto>([], null, false);
-    }
-
-    private static string BuildCursorQueryString(CursorPageParameter request)
-    {
-        var queryParams = new List<string> { $"pageSize={request.PageSize}" };
-
-        if (!string.IsNullOrEmpty(request.Cursor))
-        {
-            queryParams.Add($"cursor={Uri.EscapeDataString(request.Cursor)}");
-        }
-
-        if (!string.IsNullOrEmpty(request.Search))
-        {
-            queryParams.Add($"search={Uri.EscapeDataString(request.Search)}");
         }
 
         return "?" + string.Join("&", queryParams);

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/SpeciesHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/SpeciesHttpClient.cs
@@ -1,5 +1,4 @@
 using System.Net.Http.Json;
-using FaunaFinder.Pagination.Contracts;
 using FaunaFinder.Wildlife.Contracts.Dtos;
 using FaunaFinder.Wildlife.Contracts.Parameters;
 
@@ -30,17 +29,16 @@ public sealed class SpeciesHttpClient(HttpClient httpClient) : ISpeciesHttpClien
         );
     }
 
-    public async Task<IReadOnlyList<SpeciesForSearchDto>> GetSpeciesAsync(
+    public IAsyncEnumerable<SpeciesForSearchDto> GetSpeciesAsync(
         SpeciesParameters parameters,
         CancellationToken cancellationToken = default
     )
     {
         var queryString = BuildSpeciesQueryString(parameters);
-        var result = await httpClient.GetFromJsonAsync<IReadOnlyList<SpeciesForSearchDto>>(
+        return httpClient.GetFromJsonAsAsyncEnumerable<SpeciesForSearchDto>(
             $"api/species{queryString}",
             cancellationToken
-        );
-        return result ?? [];
+        )!;
     }
 
     public async Task<int> GetTotalSpeciesCountAsync(
@@ -71,11 +69,12 @@ public sealed class SpeciesHttpClient(HttpClient httpClient) : ISpeciesHttpClien
 
     private static string BuildSpeciesQueryString(SpeciesParameters parameters)
     {
-        var queryParams = new List<string>
+        var queryParams = new List<string> { $"pageSize={parameters.PageSize}" };
+
+        if (parameters.Cursor.HasValue)
         {
-            $"pageSize={parameters.PageSize}",
-            $"page={parameters.Page}",
-        };
+            queryParams.Add($"cursor={parameters.Cursor.Value}");
+        }
 
         if (!string.IsNullOrEmpty(parameters.Search))
         {
@@ -87,39 +86,9 @@ public sealed class SpeciesHttpClient(HttpClient httpClient) : ISpeciesHttpClien
             queryParams.Add($"municipalityId={parameters.MunicipalityId.Value}");
         }
 
-        return "?" + string.Join("&", queryParams);
-    }
-
-    public async Task<CursorPage<SpeciesForSearchDto>> GetSpeciesCursorPageAsync(
-        CursorPageParameter request,
-        CancellationToken cancellationToken = default
-    )
-    {
-        var queryString = BuildCursorQueryString(request);
-        var result = await httpClient.GetFromJsonAsync<CursorPage<SpeciesForSearchDto>>(
-            $"api/species/cursor{queryString}",
-            cancellationToken
-        );
-        return result ?? new CursorPage<SpeciesForSearchDto>([], null, false);
-    }
-
-    private static string BuildCursorQueryString(CursorPageParameter request)
-    {
-        var queryParams = new List<string> { $"pageSize={request.PageSize}" };
-
-        if (!string.IsNullOrEmpty(request.Cursor))
+        if (!string.IsNullOrEmpty(parameters.CategoryIds))
         {
-            queryParams.Add($"cursor={Uri.EscapeDataString(request.Cursor)}");
-        }
-
-        if (!string.IsNullOrEmpty(request.Search))
-        {
-            queryParams.Add($"search={Uri.EscapeDataString(request.Search)}");
-        }
-
-        if (!string.IsNullOrEmpty(request.CategoryIds))
-        {
-            queryParams.Add($"categoryIds={Uri.EscapeDataString(request.CategoryIds)}");
+            queryParams.Add($"categoryIds={Uri.EscapeDataString(parameters.CategoryIds)}");
         }
 
         return "?" + string.Join("&", queryParams);

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/FaunaFinder.Wildlife.Contracts.csproj
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/FaunaFinder.Wildlife.Contracts.csproj
@@ -9,5 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\FaunaFinder.i18n.Contracts\FaunaFinder.i18n.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\Common\FaunaFinder.Pagination.Contracts\FaunaFinder.Pagination.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Parameters/MunicipalityParameters.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Parameters/MunicipalityParameters.cs
@@ -1,3 +1,9 @@
+using FaunaFinder.Pagination.Contracts;
+
 namespace FaunaFinder.Wildlife.Contracts.Parameters;
 
-public sealed record MunicipalityParameters(int PageSize = 12, int Page = 0, string? Search = null);
+public sealed record MunicipalityParameters(
+    int PageSize = 20,
+    int? Cursor = null,
+    string? Search = null
+) : KeysetPagination<int>(PageSize, Cursor);

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Parameters/SightingsParameters.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Parameters/SightingsParameters.cs
@@ -1,3 +1,7 @@
 namespace FaunaFinder.Wildlife.Contracts.Parameters;
 
-public sealed record SightingsParameters(int Page = 1, int PageSize = 20, string? Status = null);
+public sealed record SightingsParameters(
+    int PageSize = 20,
+    int Page = 1,
+    string? Status = null
+);

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Parameters/SpeciesParameters.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Parameters/SpeciesParameters.cs
@@ -1,9 +1,11 @@
+using FaunaFinder.Pagination.Contracts;
+
 namespace FaunaFinder.Wildlife.Contracts.Parameters;
 
 public sealed record SpeciesParameters(
-    int PageSize = 12,
-    int Page = 0,
+    int PageSize = 20,
+    int? Cursor = null,
     string? Search = null,
     int? MunicipalityId = null,
     string? CategoryIds = null
-);
+) : KeysetPagination<int>(PageSize, Cursor);

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Validators/SightingsParametersValidator.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Validators/SightingsParametersValidator.cs
@@ -9,11 +9,13 @@ public sealed class SightingsParametersValidator : AbstractValidator<SightingsPa
 
     public SightingsParametersValidator()
     {
-        RuleFor(x => x.Page).GreaterThanOrEqualTo(1).WithMessage("Page must be at least 1");
-
         RuleFor(x => x.PageSize)
             .InclusiveBetween(1, 100)
             .WithMessage("PageSize must be between 1 and 100");
+
+        RuleFor(x => x.Page)
+            .GreaterThanOrEqualTo(1)
+            .WithMessage("Page must be at least 1");
 
         RuleFor(x => x.Status)
             .Must(status =>

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Interfaces/IMunicipalityRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Interfaces/IMunicipalityRepository.cs
@@ -15,18 +15,13 @@ public interface IMunicipalityRepository
         CancellationToken cancellationToken = default
     );
 
-    Task<IReadOnlyList<MunicipalityCardDto>> GetMunicipalitiesWithSpeciesCountAsync(
+    IAsyncEnumerable<MunicipalityCardDto> GetMunicipalitiesWithSpeciesCountAsync(
         MunicipalityParameters parameters,
         CancellationToken cancellationToken = default
     );
 
     Task<int> GetTotalMunicipalitiesCountAsync(
         string? search = null,
-        CancellationToken cancellationToken = default
-    );
-
-    Task<CursorPage<MunicipalityCardDto>> GetMunicipalitiesCursorPageAsync(
-        CursorPageParameter request,
         CancellationToken cancellationToken = default
     );
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Interfaces/ISpeciesRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Interfaces/ISpeciesRepository.cs
@@ -18,7 +18,7 @@ public interface ISpeciesRepository
         CancellationToken cancellationToken = default
     );
 
-    Task<IReadOnlyList<SpeciesForSearchDto>> GetSpeciesAsync(
+    IAsyncEnumerable<SpeciesForSearchDto> GetSpeciesAsync(
         SpeciesParameters parameters,
         CancellationToken cancellationToken = default
     );
@@ -40,11 +40,6 @@ public interface ISpeciesRepository
         double latitude,
         double longitude,
         double radiusMeters,
-        CancellationToken cancellationToken = default
-    );
-
-    Task<CursorPage<SpeciesForSearchDto>> GetSpeciesCursorPageAsync(
-        CursorPageParameter request,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/MunicipalityRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/MunicipalityRepository.cs
@@ -42,9 +42,17 @@ public sealed class MunicipalityRepository(IDbContextFactory<WildlifeDbContext> 
             .FirstOrDefaultAsync(cancellationToken);
     }
 
-    public async Task<IReadOnlyList<MunicipalityCardDto>> GetMunicipalitiesWithSpeciesCountAsync(
+    public IAsyncEnumerable<MunicipalityCardDto> GetMunicipalitiesWithSpeciesCountAsync(
         MunicipalityParameters parameters,
         CancellationToken cancellationToken = default
+    )
+    {
+        return GetMunicipalitiesInternalAsync(parameters, cancellationToken);
+    }
+
+    private async IAsyncEnumerable<MunicipalityCardDto> GetMunicipalitiesInternalAsync(
+        MunicipalityParameters parameters,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default
     )
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
@@ -57,12 +65,22 @@ public sealed class MunicipalityRepository(IDbContextFactory<WildlifeDbContext> 
             query = query.Where(m => m.Name.ToLower().Contains(search));
         }
 
-        return await query
-            .OrderBy(static m => m.Name)
-            .Skip(parameters.Page * parameters.PageSize)
-            .Take(parameters.PageSize)
+        // Apply cursor filter
+        if (parameters.Cursor.HasValue)
+        {
+            query = query.Where(m => m.Id > parameters.Cursor.Value);
+        }
+
+        // Fetch PageSize + 1 for client-side HasMore detection
+        await foreach (var municipality in query
+            .OrderBy(m => m.Id)
+            .Take(parameters.PageSize + 1)
             .Select(static m => new MunicipalityCardDto(m.Id, m.Name, m.MunicipalitySpecies.Count))
-            .ToListAsync(cancellationToken);
+            .AsAsyncEnumerable()
+            .WithCancellation(cancellationToken))
+        {
+            yield return municipality;
+        }
     }
 
     public async Task<int> GetTotalMunicipalitiesCountAsync(
@@ -81,45 +99,5 @@ public sealed class MunicipalityRepository(IDbContextFactory<WildlifeDbContext> 
         }
 
         return await query.CountAsync(cancellationToken);
-    }
-
-    public async Task<CursorPage<MunicipalityCardDto>> GetMunicipalitiesCursorPageAsync(
-        CursorPageParameter request,
-        CancellationToken cancellationToken = default
-    )
-    {
-        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
-
-        var query = context.Municipalities.AsNoTracking().AsQueryable();
-
-        // Apply search filter
-        if (!string.IsNullOrWhiteSpace(request.Search))
-        {
-            var search = request.Search.ToLower();
-            query = query.Where(m => m.Name.ToLower().Contains(search));
-        }
-
-        // Apply cursor filter
-        if (request.Cursor is not null && CursorHelper.TryDecode(request.Cursor, out var cursorId))
-        {
-            query = query.Where(m => m.Id > cursorId);
-        }
-
-        // Fetch one extra to determine HasMore
-        var items = await query
-            .OrderBy(m => m.Id)
-            .Take(request.PageSize + 1)
-            .Select(static m => new MunicipalityCardDto(m.Id, m.Name, m.MunicipalitySpecies.Count))
-            .ToListAsync(cancellationToken);
-
-        var hasMore = items.Count > request.PageSize;
-        if (hasMore)
-        {
-            items.RemoveAt(items.Count - 1);
-        }
-
-        var nextCursor = hasMore && items.Count > 0 ? CursorHelper.Encode(items[^1].Id) : null;
-
-        return new CursorPage<MunicipalityCardDto>(items, nextCursor, hasMore);
     }
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
@@ -94,9 +94,17 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
             .FirstOrDefaultAsync(cancellationToken);
     }
 
-    public async Task<IReadOnlyList<SpeciesForSearchDto>> GetSpeciesAsync(
+    public IAsyncEnumerable<SpeciesForSearchDto> GetSpeciesAsync(
         SpeciesParameters parameters,
         CancellationToken cancellationToken = default
+    )
+    {
+        return GetSpeciesInternalAsync(parameters, cancellationToken);
+    }
+
+    private async IAsyncEnumerable<SpeciesForSearchDto> GetSpeciesInternalAsync(
+        SpeciesParameters parameters,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default
     )
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
@@ -140,11 +148,16 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
             );
         }
 
-        // Project and return with municipality names
-        return await query
-            .OrderBy(s => s.ScientificName)
-            .Skip(parameters.Page * parameters.PageSize)
-            .Take(parameters.PageSize)
+        // Apply cursor filter
+        if (parameters.Cursor.HasValue)
+        {
+            query = query.Where(s => s.Id > parameters.Cursor.Value);
+        }
+
+        // Fetch PageSize + 1 for client-side HasMore detection
+        await foreach (var species in query
+            .OrderBy(s => s.Id)
+            .Take(parameters.PageSize + 1)
             .Select(s => new SpeciesForSearchDto(
                 s.Id,
                 s.CommonName.ToList(),
@@ -152,7 +165,11 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
                 s.MunicipalitySpecies.Select(ms => ms.Municipality.Name).OrderBy(n => n).ToList(),
                 s.IsFauna
             ))
-            .ToListAsync(cancellationToken);
+            .AsAsyncEnumerable()
+            .WithCancellation(cancellationToken))
+        {
+            yield return species;
+        }
     }
 
     public async Task<int> GetTotalSpeciesCountAsync(
@@ -283,73 +300,6 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
     private static double DegreesToRadians(double degrees)
     {
         return degrees * Math.PI / 180;
-    }
-
-    public async Task<CursorPage<SpeciesForSearchDto>> GetSpeciesCursorPageAsync(
-        CursorPageParameter request,
-        CancellationToken cancellationToken = default
-    )
-    {
-        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
-
-        var query = context.Species.AsNoTracking().AsQueryable();
-
-        // Apply category filter (comma-separated IDs)
-        if (!string.IsNullOrWhiteSpace(request.CategoryIds))
-        {
-            var categoryIds = request.CategoryIds
-                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select(id => int.TryParse(id, out var parsed) ? parsed : (int?)null)
-                .Where(id => id.HasValue)
-                .Select(id => id!.Value)
-                .ToList();
-
-            if (categoryIds.Count > 0)
-            {
-                query = query.Where(s =>
-                    s.CategoryLinks.Any(cl => categoryIds.Contains(cl.CategoryId))
-                );
-            }
-        }
-
-        // Apply search filter
-        if (!string.IsNullOrWhiteSpace(request.Search))
-        {
-            var search = request.Search.Trim().ToLower();
-            query = query.Where(s =>
-                s.CommonName.Any(cn => cn.Value.ToLower().Contains(search))
-                || s.ScientificName.ToLower().Contains(search)
-            );
-        }
-
-        // Apply cursor filter
-        if (request.Cursor is not null && CursorHelper.TryDecode(request.Cursor, out var cursorId))
-        {
-            query = query.Where(s => s.Id > cursorId);
-        }
-
-        // Fetch one extra to determine HasMore
-        var items = await query
-            .OrderBy(s => s.Id)
-            .Take(request.PageSize + 1)
-            .Select(s => new SpeciesForSearchDto(
-                s.Id,
-                s.CommonName.ToList(),
-                s.ScientificName,
-                s.MunicipalitySpecies.Select(ms => ms.Municipality.Name).OrderBy(n => n).ToList(),
-                s.IsFauna
-            ))
-            .ToListAsync(cancellationToken);
-
-        var hasMore = items.Count > request.PageSize;
-        if (hasMore)
-        {
-            items.RemoveAt(items.Count - 1);
-        }
-
-        var nextCursor = hasMore && items.Count > 0 ? CursorHelper.Encode(items[^1].Id) : null;
-
-        return new CursorPage<SpeciesForSearchDto>(items, nextCursor, hasMore);
     }
 
     public async Task<IReadOnlyList<SpeciesCategoryDto>> GetAllCategoriesAsync(


### PR DESCRIPTION
## Summary
- Replaces offset-based pagination with typed cursor (keyset) pagination for Species and Municipality endpoints
- Introduces `KeysetPagination<TKey>` base record with reusable validator for standardized pagination
- Implements PageSize+1 pattern where server streams one extra item for client-side hasMore detection
- Uses `IAsyncEnumerable<T>` for efficient streaming responses instead of `CursorPage<T>` wrapper

## Changes
- **New**: `KeysetPagination<TKey>` base record and `KeysetPaginationValidator<TKey>`
- **Updated**: `SpeciesParameters` and `MunicipalityParameters` now use typed `int? Cursor`
- **Updated**: Repositories return `IAsyncEnumerable` with PageSize+1 items
- **Updated**: HTTP clients use `GetFromJsonAsAsyncEnumerable` for streaming
- **Updated**: Species.razor and Pueblos.razor use new pagination pattern

## Test plan
- [ ] Verify infinite scroll works on Species page
- [ ] Verify infinite scroll works on Pueblos page
- [ ] Verify search filtering continues to work with new pagination
- [ ] Verify category filtering works on Species page
- [ ] Confirm no regressions in sighting review queue (kept offset pagination)

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)