### PR TITLE
Refactor: Use Azure PostgreSQL Flexible Server explicitly

### DIFF
--- a/src/FaunaFinder.AppHost/Extensions/DatabaseExtensions.cs
+++ b/src/FaunaFinder.AppHost/Extensions/DatabaseExtensions.cs
@@ -1,4 +1,5 @@
 using Aspire.Hosting;
+using Aspire.Hosting.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
@@ -7,74 +8,91 @@ namespace FaunaFinder.AppHost.Extensions;
 
 public static class DatabaseExtensions
 {
+    public static IResourceBuilder<AzurePostgresFlexibleServerDatabaseResource> WithDropDatabaseCommand(
+        this IResourceBuilder<AzurePostgresFlexibleServerDatabaseResource> builder)
+    {
+        var databaseName = builder.Resource.Name;
+
+        return builder.WithCommand(
+            name: "drop-database",
+            displayName: "Drop & Recreate",
+            executeCommand: context => ExecuteDropDatabaseAsync(context, builder.Resource.Parent, databaseName),
+            commandOptions: CreateCommandOptions(databaseName));
+    }
+
     public static IResourceBuilder<PostgresDatabaseResource> WithDropDatabaseCommand(
         this IResourceBuilder<PostgresDatabaseResource> builder)
     {
         var databaseName = builder.Resource.DatabaseName;
 
-        var commandOptions = new CommandOptions
-        {
-            UpdateState = context => context.ResourceSnapshot.HealthStatus is HealthStatus.Healthy
-                ? ResourceCommandState.Enabled
-                : ResourceCommandState.Disabled,
-            IconName = "Delete",
-            IconVariant = IconVariant.Filled,
-            ConfirmationMessage = $"Are you sure you want to drop and recreate '{databaseName}'?"
-        };
-
         return builder.WithCommand(
             name: "drop-database",
             displayName: "Drop & Recreate",
-            executeCommand: async context =>
+            executeCommand: context => ExecuteDropDatabaseAsync(context, builder.Resource.Parent, databaseName),
+            commandOptions: CreateCommandOptions(databaseName));
+    }
+
+    private static CommandOptions CreateCommandOptions(string databaseName) => new()
+    {
+        UpdateState = context => context.ResourceSnapshot.HealthStatus is HealthStatus.Healthy
+            ? ResourceCommandState.Enabled
+            : ResourceCommandState.Disabled,
+        IconName = "Delete",
+        IconVariant = IconVariant.Filled,
+        ConfirmationMessage = $"Are you sure you want to drop and recreate '{databaseName}'?"
+    };
+
+    private static async Task<ExecuteCommandResult> ExecuteDropDatabaseAsync(
+        ExecuteCommandContext context,
+        IResourceWithConnectionString parentResource,
+        string databaseName)
+    {
+        var logger = context.ServiceProvider.GetRequiredService<ILogger<PostgresDatabaseResource>>();
+        var connectionString = await parentResource.GetConnectionStringAsync(context.CancellationToken);
+
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            return CommandResults.Failure("Could not get connection string");
+        }
+
+        try
+        {
+            await using var conn = new Npgsql.NpgsqlConnection(connectionString);
+            await conn.OpenAsync(context.CancellationToken);
+
+            // Terminate existing connections
+            await using (var cmd = conn.CreateCommand())
             {
-                var logger = context.ServiceProvider.GetRequiredService<ILogger<PostgresDatabaseResource>>();
-                var connectionString = await builder.Resource.Parent.GetConnectionStringAsync(context.CancellationToken);
+                cmd.CommandText = $"""
+                    SELECT pg_terminate_backend(pg_stat_activity.pid)
+                    FROM pg_stat_activity
+                    WHERE pg_stat_activity.datname = '{databaseName}'
+                    AND pid <> pg_backend_pid();
+                    """;
+                await cmd.ExecuteNonQueryAsync(context.CancellationToken);
+            }
 
-                if (string.IsNullOrEmpty(connectionString))
-                {
-                    return CommandResults.Failure("Could not get connection string");
-                }
+            // Drop database
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = $"DROP DATABASE IF EXISTS \"{databaseName}\"";
+                await cmd.ExecuteNonQueryAsync(context.CancellationToken);
+            }
 
-                try
-                {
-                    await using var conn = new Npgsql.NpgsqlConnection(connectionString);
-                    await conn.OpenAsync(context.CancellationToken);
+            // Recreate database
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = $"CREATE DATABASE \"{databaseName}\"";
+                await cmd.ExecuteNonQueryAsync(context.CancellationToken);
+            }
 
-                    // Terminate existing connections
-                    await using (var cmd = conn.CreateCommand())
-                    {
-                        cmd.CommandText = $"""
-                            SELECT pg_terminate_backend(pg_stat_activity.pid)
-                            FROM pg_stat_activity
-                            WHERE pg_stat_activity.datname = '{databaseName}'
-                            AND pid <> pg_backend_pid();
-                            """;
-                        await cmd.ExecuteNonQueryAsync(context.CancellationToken);
-                    }
-
-                    // Drop database
-                    await using (var cmd = conn.CreateCommand())
-                    {
-                        cmd.CommandText = $"DROP DATABASE IF EXISTS \"{databaseName}\"";
-                        await cmd.ExecuteNonQueryAsync(context.CancellationToken);
-                    }
-
-                    // Recreate database
-                    await using (var cmd = conn.CreateCommand())
-                    {
-                        cmd.CommandText = $"CREATE DATABASE \"{databaseName}\"";
-                        await cmd.ExecuteNonQueryAsync(context.CancellationToken);
-                    }
-
-                    logger.LogInformation("Database '{DatabaseName}' dropped and recreated", databaseName);
-                    return CommandResults.Success();
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to drop database '{DatabaseName}'", databaseName);
-                    return CommandResults.Failure($"Failed: {ex.Message}");
-                }
-            },
-            commandOptions: commandOptions);
+            logger.LogInformation("Database '{DatabaseName}' dropped and recreated", databaseName);
+            return CommandResults.Success();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to drop database '{DatabaseName}'", databaseName);
+            return CommandResults.Failure($"Failed: {ex.Message}");
+        }
     }
 }

--- a/src/FaunaFinder.AppHost/Program.cs
+++ b/src/FaunaFinder.AppHost/Program.cs
@@ -3,10 +3,11 @@ using FaunaFinder.AppHost.Extensions;
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder
-    .AddPostgres("postgres")
-    .WithImage("postgis/postgis", "17-3.5")
-    .WithDataVolume("faunafinder-postgres-data")
-    .WithPgAdmin();
+    .AddAzurePostgresFlexibleServer("postgres")
+    .RunAsContainer(c => c
+        .WithImage("postgis/postgis", "17-3.5")
+        .WithDataVolume("faunafinder-postgres-data")
+        .WithPgAdmin());
 
 var identityDb = postgres.AddDatabase("faunafinder-identity").WithDropDatabaseCommand();
 var wildlifeDb = postgres.AddDatabase("faunafinder-wildlife").WithDropDatabaseCommand();


### PR DESCRIPTION
## Summary
- Change from `AddPostgres` to `AddAzurePostgresFlexibleServer` with `RunAsContainer` pattern
- Update `DatabaseExtensions` to support both `AzurePostgresFlexibleServerDatabaseResource` and `PostgresDatabaseResource` types
- Maintains local dev experience with PostGIS container while explicitly targeting Azure Flexible Server for production deployments

## Changes
- `Program.cs`: Use `AddAzurePostgresFlexibleServer("postgres").RunAsContainer(...)` instead of `AddPostgres("postgres")`
- `DatabaseExtensions.cs`: Add overload for Azure resource type, refactor to share common logic

## Test plan
- [ ] Run locally with `dotnet run --project src/FaunaFinder.AppHost` - should start PostGIS container as before
- [ ] Verify Drop & Recreate command works in Aspire dashboard
- [ ] Deploy to Azure - should use Flexible Server