### PR TITLE
Feat: Add public statistics dashboard with charts

### DIFF
--- a/src/FaunaFinder.Client/FaunaFinder.Client.csproj
+++ b/src/FaunaFinder.Client/FaunaFinder.Client.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageReference Include="BlazingSingularity" Version="1.0.0-beta.3" />
     <PackageReference Include="MudBlazor" Version="8.4.0" />
+    <PackageReference Include="Blazor-ApexCharts" Version="3.7.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\FaunaFinder.i18n.Contracts\FaunaFinder.i18n.Contracts.csproj" />

--- a/src/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/FaunaFinder.Client/Layout/MainLayout.razor
@@ -23,6 +23,7 @@
             <MudButton Href="/species" Color="Color.Inherit" Variant="Variant.Text">@L["Nav_Species"]</MudButton>
             <MudButton Href="/pueblos" Color="Color.Inherit" Variant="Variant.Text">@L["Nav_Pueblos"]</MudButton>
             <MudButton Href="/about" Color="Color.Inherit" Variant="Variant.Text">@L["Nav_About"]</MudButton>
+            <MudButton Href="/statistics" Color="Color.Inherit" Variant="Variant.Text">@L["Nav_Statistics"]</MudButton>
             <AuthorizeView>
                 <Authorized>
                     <MudButton Href="/sightings" Color="Color.Inherit" Variant="Variant.Text">@L["Nav_Sightings"]</MudButton>
@@ -55,6 +56,7 @@
             <MudNavLink Href="/species" Icon="@Icons.Material.Filled.Pets" OnClick="CloseDrawer">@L["Nav_Species"]</MudNavLink>
             <MudNavLink Href="/pueblos" Icon="@Icons.Material.Filled.LocationCity" OnClick="CloseDrawer">@L["Nav_Pueblos"]</MudNavLink>
             <MudNavLink Href="/about" Icon="@Icons.Material.Filled.Info" OnClick="CloseDrawer">@L["Nav_About"]</MudNavLink>
+            <MudNavLink Href="/statistics" Icon="@Icons.Material.Filled.BarChart" OnClick="CloseDrawer">@L["Nav_Statistics"]</MudNavLink>
             <AuthorizeView>
                 <Authorized>
                     <MudNavLink Href="/sightings" Icon="@Icons.Material.Filled.PhotoLibrary" OnClick="CloseDrawer">@L["Nav_Sightings"]</MudNavLink>

--- a/src/FaunaFinder.Client/Pages/Statistics.razor
+++ b/src/FaunaFinder.Client/Pages/Statistics.razor
@@ -1,0 +1,272 @@
+@page "/statistics"
+@inject IAppLocalizer L
+@inject IWildlifeHttpClient WildlifeClient
+
+<PageTitle>@L["PageTitle_Statistics"]</PageTitle>
+
+@code {
+    private PublicStatisticsDto? _statistics;
+    private bool _loading = true;
+    private string? _error;
+
+    protected override void OnInitialized()
+    {
+        L.LanguageSignal.OnChange(async () => await InvokeAsync(StateHasChanged));
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadStatisticsAsync();
+    }
+
+    private async Task LoadStatisticsAsync()
+    {
+        try
+        {
+            _loading = true;
+            _statistics = await WildlifeClient.GetPublicStatisticsAsync();
+        }
+        catch (Exception)
+        {
+            _error = L["Error_UnexpectedError"];
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private ApexChartOptions<SightingsByMonthDto> GetLineChartOptions() => new()
+    {
+        Chart = new Chart
+        {
+            Background = "transparent",
+            Toolbar = new Toolbar { Show = false }
+        },
+        Stroke = new Stroke { Curve = Curve.Smooth, Width = 3 },
+        Xaxis = new XAxis
+        {
+            Categories = _statistics?.SightingsByMonth
+                .Select(x => $"{x.Year}-{x.Month:D2}")
+                .ToList()
+        },
+        Colors = ["#1976d2"]
+    };
+
+    private ApexChartOptions<SpeciesByCategoryDto> GetDonutChartOptions() => new()
+    {
+        Chart = new Chart
+        {
+            Background = "transparent"
+        },
+        Labels = _statistics?.SpeciesByCategory.Select(x => x.Category).ToList(),
+        Colors = ["#4caf50", "#2196f3"]
+    };
+
+    private ApexChartOptions<SightingsByMunicipalityDto> GetBarChartOptions() => new()
+    {
+        Chart = new Chart
+        {
+            Background = "transparent",
+            Toolbar = new Toolbar { Show = false }
+        },
+        PlotOptions = new PlotOptions
+        {
+            Bar = new PlotOptionsBar
+            {
+                Horizontal = true,
+                BorderRadius = 4
+            }
+        },
+        Colors = ["#ff9800"]
+    };
+
+    private ApexChartOptions<TopSpeciesDto> GetTopSpeciesChartOptions() => new()
+    {
+        Chart = new Chart
+        {
+            Background = "transparent",
+            Toolbar = new Toolbar { Show = false }
+        },
+        PlotOptions = new PlotOptions
+        {
+            Bar = new PlotOptionsBar
+            {
+                Horizontal = true,
+                BorderRadius = 4
+            }
+        },
+        Colors = ["#9c27b0"]
+    };
+
+    private string GetMonthLabel(int year, int month)
+    {
+        var date = new DateTime(year, month, 1);
+        return date.ToString("MMM yyyy");
+    }
+}
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-8">
+    <MudText Typo="Typo.h4" Color="Color.Primary" GutterBottom="true">@L["Statistics_Title"]</MudText>
+    <MudText Typo="Typo.body1" Class="mb-6">@L["Statistics_Description"]</MudText>
+
+    @if (_loading)
+    {
+        <MudGrid>
+            @for (int i = 0; i < 4; i++)
+            {
+                <MudItem xs="12" sm="6" md="3">
+                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="120px" />
+                </MudItem>
+            }
+        </MudGrid>
+        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="300px" Class="mt-6" />
+    }
+    else if (_error != null)
+    {
+        <MudAlert Severity="Severity.Error" Class="mb-4">@_error</MudAlert>
+    }
+    else if (_statistics != null)
+    {
+        <!-- Overview Cards -->
+        <MudGrid Class="mb-6">
+            <MudItem xs="12" sm="6" md="3">
+                <MudPaper Elevation="2" Class="pa-4 text-center">
+                    <MudIcon Icon="@Icons.Material.Filled.Visibility" Size="Size.Large" Color="Color.Primary" />
+                    <MudText Typo="Typo.h4" Color="Color.Primary">@_statistics.Overview.TotalApprovedSightings</MudText>
+                    <MudText Typo="Typo.body2">@L["Statistics_TotalSightings"]</MudText>
+                </MudPaper>
+            </MudItem>
+            <MudItem xs="12" sm="6" md="3">
+                <MudPaper Elevation="2" Class="pa-4 text-center">
+                    <MudIcon Icon="@Icons.Material.Filled.Pets" Size="Size.Large" Color="Color.Success" />
+                    <MudText Typo="Typo.h4" Color="Color.Success">@_statistics.Overview.TotalSpecies</MudText>
+                    <MudText Typo="Typo.body2">@L["Statistics_TotalSpecies"]</MudText>
+                </MudPaper>
+            </MudItem>
+            <MudItem xs="12" sm="6" md="3">
+                <MudPaper Elevation="2" Class="pa-4 text-center">
+                    <MudIcon Icon="@Icons.Material.Filled.Map" Size="Size.Large" Color="Color.Warning" />
+                    <MudText Typo="Typo.h4" Color="Color.Warning">@_statistics.Overview.TotalMunicipalities</MudText>
+                    <MudText Typo="Typo.body2">@L["Statistics_TotalMunicipalities"]</MudText>
+                </MudPaper>
+            </MudItem>
+            <MudItem xs="12" sm="6" md="3">
+                <MudPaper Elevation="2" Class="pa-4 text-center">
+                    <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Size="Size.Large" Color="Color.Secondary" />
+                    <MudText Typo="Typo.h4" Color="Color.Secondary">@_statistics.Overview.SightingsThisMonth</MudText>
+                    <MudText Typo="Typo.body2">@L["Statistics_ThisMonth"]</MudText>
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+
+        <!-- Charts Row 1 -->
+        <MudGrid Class="mb-6">
+            <!-- Sightings Over Time -->
+            <MudItem xs="12" md="8">
+                <MudPaper Elevation="2" Class="pa-4">
+                    <MudText Typo="Typo.h6" GutterBottom="true">@L["Statistics_SightingsOverTime"]</MudText>
+                    @if (_statistics.SightingsByMonth.Any())
+                    {
+                        <ApexChart TItem="SightingsByMonthDto"
+                                   Options="GetLineChartOptions()"
+                                   Height="300">
+                            <ApexPointSeries TItem="SightingsByMonthDto"
+                                           Items="_statistics.SightingsByMonth"
+                                           SeriesType="SeriesType.Line"
+                                           Name="@L["Statistics_Sightings"]"
+                                           XValue="@(e => GetMonthLabel(e.Year, e.Month))"
+                                           YValue="@(e => (decimal)e.Count)" />
+                        </ApexChart>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Default" Class="text-center py-8">
+                            @L["Statistics_NoData"]
+                        </MudText>
+                    }
+                </MudPaper>
+            </MudItem>
+
+            <!-- Species by Category -->
+            <MudItem xs="12" md="4">
+                <MudPaper Elevation="2" Class="pa-4">
+                    <MudText Typo="Typo.h6" GutterBottom="true">@L["Statistics_SpeciesByCategory"]</MudText>
+                    @if (_statistics.SpeciesByCategory.Any())
+                    {
+                        <ApexChart TItem="SpeciesByCategoryDto"
+                                   Options="GetDonutChartOptions()"
+                                   Height="300">
+                            <ApexPointSeries TItem="SpeciesByCategoryDto"
+                                           Items="_statistics.SpeciesByCategory"
+                                           SeriesType="SeriesType.Donut"
+                                           XValue="@(e => e.Category)"
+                                           YValue="@(e => (decimal)e.Count)" />
+                        </ApexChart>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Default" Class="text-center py-8">
+                            @L["Statistics_NoData"]
+                        </MudText>
+                    }
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+
+        <!-- Charts Row 2 -->
+        <MudGrid>
+            <!-- Sightings by Municipality -->
+            <MudItem xs="12" md="6">
+                <MudPaper Elevation="2" Class="pa-4">
+                    <MudText Typo="Typo.h6" GutterBottom="true">@L["Statistics_SightingsByMunicipality"]</MudText>
+                    @if (_statistics.SightingsByMunicipality.Any())
+                    {
+                        <ApexChart TItem="SightingsByMunicipalityDto"
+                                   Options="GetBarChartOptions()"
+                                   Height="350">
+                            <ApexPointSeries TItem="SightingsByMunicipalityDto"
+                                           Items="_statistics.SightingsByMunicipality"
+                                           SeriesType="SeriesType.Bar"
+                                           Name="@L["Statistics_Sightings"]"
+                                           XValue="@(e => e.MunicipalityName)"
+                                           YValue="@(e => (decimal)e.SightingsCount)" />
+                        </ApexChart>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Default" Class="text-center py-8">
+                            @L["Statistics_NoData"]
+                        </MudText>
+                    }
+                </MudPaper>
+            </MudItem>
+
+            <!-- Top Observed Species -->
+            <MudItem xs="12" md="6">
+                <MudPaper Elevation="2" Class="pa-4">
+                    <MudText Typo="Typo.h6" GutterBottom="true">@L["Statistics_TopSpecies"]</MudText>
+                    @if (_statistics.TopSpecies.Any())
+                    {
+                        <ApexChart TItem="TopSpeciesDto"
+                                   Options="GetTopSpeciesChartOptions()"
+                                   Height="350">
+                            <ApexPointSeries TItem="TopSpeciesDto"
+                                           Items="_statistics.TopSpecies"
+                                           SeriesType="SeriesType.Bar"
+                                           Name="@L["Statistics_Sightings"]"
+                                           XValue="@(e => e.SpeciesName)"
+                                           YValue="@(e => (decimal)e.SightingsCount)" />
+                        </ApexChart>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Default" Class="text-center py-8">
+                            @L["Statistics_NoData"]
+                        </MudText>
+                    }
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+    }
+</MudContainer>

--- a/src/FaunaFinder.Client/Services/Localization/Translations.cs
+++ b/src/FaunaFinder.Client/Services/Localization/Translations.cs
@@ -370,6 +370,22 @@ public static class Translations
             ["ReviewQueue_CloseDetails"] = "Close",
             ["ReviewQueue_Unauthorized"] = "You do not have permission to access this page.",
             ["Nav_ReviewQueue"] = "Review Queue",
+
+            // Statistics
+            ["Nav_Statistics"] = "Statistics",
+            ["PageTitle_Statistics"] = "Statistics - FaunaFinder",
+            ["Statistics_Title"] = "Wildlife Statistics",
+            ["Statistics_Description"] = "Explore aggregated data and trends from wildlife sightings across Puerto Rico.",
+            ["Statistics_TotalSightings"] = "Total Sightings",
+            ["Statistics_TotalSpecies"] = "Species in Database",
+            ["Statistics_TotalMunicipalities"] = "Municipalities",
+            ["Statistics_ThisMonth"] = "Sightings This Month",
+            ["Statistics_SightingsOverTime"] = "Sightings Over Time",
+            ["Statistics_SpeciesByCategory"] = "Species by Category",
+            ["Statistics_SightingsByMunicipality"] = "Top Municipalities by Sightings",
+            ["Statistics_TopSpecies"] = "Most Observed Species",
+            ["Statistics_Sightings"] = "Sightings",
+            ["Statistics_NoData"] = "No data available yet.",
         };
 
     public static IReadOnlyDictionary<string, string> Spanish { get; } =
@@ -751,5 +767,21 @@ public static class Translations
             ["ReviewQueue_CloseDetails"] = "Cerrar",
             ["ReviewQueue_Unauthorized"] = "No tienes permiso para acceder a esta página.",
             ["Nav_ReviewQueue"] = "Cola de Revisión",
+
+            // Statistics
+            ["Nav_Statistics"] = "Estadísticas",
+            ["PageTitle_Statistics"] = "Estadísticas - FaunaFinder",
+            ["Statistics_Title"] = "Estadísticas de Vida Silvestre",
+            ["Statistics_Description"] = "Explora datos agregados y tendencias de avistamientos de vida silvestre en Puerto Rico.",
+            ["Statistics_TotalSightings"] = "Total de Avistamientos",
+            ["Statistics_TotalSpecies"] = "Especies en Base de Datos",
+            ["Statistics_TotalMunicipalities"] = "Municipios",
+            ["Statistics_ThisMonth"] = "Avistamientos Este Mes",
+            ["Statistics_SightingsOverTime"] = "Avistamientos a lo Largo del Tiempo",
+            ["Statistics_SpeciesByCategory"] = "Especies por Categoría",
+            ["Statistics_SightingsByMunicipality"] = "Principales Municipios por Avistamientos",
+            ["Statistics_TopSpecies"] = "Especies Más Observadas",
+            ["Statistics_Sightings"] = "Avistamientos",
+            ["Statistics_NoData"] = "No hay datos disponibles aún.",
         };
 }

--- a/src/FaunaFinder.Client/_Imports.razor
+++ b/src/FaunaFinder.Client/_Imports.razor
@@ -22,3 +22,4 @@
 @using BlazingSingularity
 @using BlazingSingularity.Commands
 @using MudBlazor
+@using ApexCharts

--- a/src/FaunaFinder.Server/Endpoints/StatisticsEndpoints.cs
+++ b/src/FaunaFinder.Server/Endpoints/StatisticsEndpoints.cs
@@ -1,0 +1,23 @@
+using FaunaFinder.Wildlife.Contracts.Dtos;
+using FaunaFinder.Wildlife.DataAccess.Interfaces;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace FaunaFinder.Server.Endpoints;
+
+public static class StatisticsEndpoints
+{
+    public static void MapStatisticsEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/statistics").WithTags("Statistics");
+
+        group.MapGet("/", GetPublicStatistics).WithName("GetPublicStatistics");
+    }
+
+    private static async Task<Ok<PublicStatisticsDto>> GetPublicStatistics(
+        IStatisticsRepository repository,
+        CancellationToken ct)
+    {
+        var statistics = await repository.GetPublicStatisticsAsync(ct);
+        return TypedResults.Ok(statistics);
+    }
+}

--- a/src/FaunaFinder.Server/Program.cs
+++ b/src/FaunaFinder.Server/Program.cs
@@ -128,6 +128,7 @@ api.MapSpeciesImageEndpoints();
 api.MapExportEndpoints();
 api.MapIdentityEndpoints();
 api.MapSightingsEndpoints();
+api.MapStatisticsEndpoints();
 
 // Serve App.razor as the shell with WASM interactivity
 app.MapRazorComponents<App>()

--- a/src/FaunaFinder.Server/Services/Localization/Translations.cs
+++ b/src/FaunaFinder.Server/Services/Localization/Translations.cs
@@ -10,6 +10,7 @@ public static class Translations
             ["Nav_Species"] = "Species",
             ["Nav_Pueblos"] = "Municipalities",
             ["Nav_About"] = "About",
+            ["Nav_Statistics"] = "Statistics",
 
             // Common
             ["AppTitle"] = "FaunaFinder",
@@ -159,6 +160,7 @@ public static class Translations
             ["Nav_Species"] = "Especies",
             ["Nav_Pueblos"] = "Pueblos",
             ["Nav_About"] = "Acerca de",
+            ["Nav_Statistics"] = "Estadísticas",
 
             // Common
             ["AppTitle"] = "FaunaFinder",

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IWildlifeHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/IWildlifeHttpClient.cs
@@ -47,4 +47,8 @@ public interface IWildlifeHttpClient
         string? reviewNotes,
         CancellationToken cancellationToken = default
     );
+
+    Task<PublicStatisticsDto?> GetPublicStatisticsAsync(
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/WildlifeHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/WildlifeHttpClient.cs
@@ -121,6 +121,16 @@ public sealed class WildlifeHttpClient(HttpClient httpClient) : IWildlifeHttpCli
         return response.IsSuccessStatusCode;
     }
 
+    public async Task<PublicStatisticsDto?> GetPublicStatisticsAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        return await httpClient.GetFromJsonAsync<PublicStatisticsDto>(
+            "/api/statistics",
+            cancellationToken
+        );
+    }
+
     private static string GetFileExtension(string contentType) =>
         contentType.ToLowerInvariant() switch
         {

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Dtos/StatisticsDto.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Dtos/StatisticsDto.cs
@@ -1,0 +1,57 @@
+namespace FaunaFinder.Wildlife.Contracts.Dtos;
+
+/// <summary>
+/// Overview statistics for the public dashboard.
+/// </summary>
+public sealed record StatisticsOverviewDto(
+    int TotalApprovedSightings,
+    int TotalSpecies,
+    int TotalMunicipalities,
+    int SightingsThisMonth
+);
+
+/// <summary>
+/// Sightings count grouped by month for time series chart.
+/// </summary>
+public sealed record SightingsByMonthDto(
+    int Year,
+    int Month,
+    int Count
+);
+
+/// <summary>
+/// Species count grouped by category (fauna/flora).
+/// </summary>
+public sealed record SpeciesByCategoryDto(
+    string Category,
+    int Count
+);
+
+/// <summary>
+/// Species/sightings count grouped by municipality.
+/// </summary>
+public sealed record SightingsByMunicipalityDto(
+    int MunicipalityId,
+    string MunicipalityName,
+    int SightingsCount
+);
+
+/// <summary>
+/// Top observed species with sighting counts.
+/// </summary>
+public sealed record TopSpeciesDto(
+    int SpeciesId,
+    string SpeciesName,
+    int SightingsCount
+);
+
+/// <summary>
+/// Complete statistics response for the public dashboard.
+/// </summary>
+public sealed record PublicStatisticsDto(
+    StatisticsOverviewDto Overview,
+    IReadOnlyList<SightingsByMonthDto> SightingsByMonth,
+    IReadOnlyList<SpeciesByCategoryDto> SpeciesByCategory,
+    IReadOnlyList<SightingsByMunicipalityDto> SightingsByMunicipality,
+    IReadOnlyList<TopSpeciesDto> TopSpecies
+);

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Extensions/WildlifeDataAccessConfigurator.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Extensions/WildlifeDataAccessConfigurator.cs
@@ -12,6 +12,7 @@ public static class WildlifeDataAccessConfigurator
         services.AddScoped<ISpeciesRepository, SpeciesRepository>();
         services.AddScoped<ISpeciesImageRepository, SpeciesImageRepository>();
         services.AddScoped<ISightingRepository, SightingRepository>();
+        services.AddScoped<IStatisticsRepository, StatisticsRepository>();
 
         return services;
     }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Interfaces/IStatisticsRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Interfaces/IStatisticsRepository.cs
@@ -1,0 +1,8 @@
+using FaunaFinder.Wildlife.Contracts.Dtos;
+
+namespace FaunaFinder.Wildlife.DataAccess.Interfaces;
+
+public interface IStatisticsRepository
+{
+    Task<PublicStatisticsDto> GetPublicStatisticsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/StatisticsRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/StatisticsRepository.cs
@@ -1,0 +1,99 @@
+using FaunaFinder.Wildlife.Contracts.Dtos;
+using FaunaFinder.Wildlife.DataAccess.Interfaces;
+using FaunaFinder.Wildlife.Database;
+using FaunaFinder.Wildlife.Database.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace FaunaFinder.Wildlife.DataAccess.Repositories;
+
+public sealed class StatisticsRepository(IDbContextFactory<WildlifeDbContext> contextFactory)
+    : IStatisticsRepository
+{
+    public async Task<PublicStatisticsDto> GetPublicStatisticsAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var approvedSightings = context.Sightings.Where(s => s.Status == SightingStatus.Approved);
+
+        // Overview statistics
+        var totalApprovedSightings = await approvedSightings.CountAsync(cancellationToken);
+
+        var totalSpecies = await context.Species.CountAsync(cancellationToken);
+
+        var totalMunicipalities = await context.Municipalities.CountAsync(cancellationToken);
+
+        var startOfMonth = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var sightingsThisMonth = await approvedSightings
+            .Where(s => s.ObservedAt >= startOfMonth)
+            .CountAsync(cancellationToken);
+
+        var overview = new StatisticsOverviewDto(
+            totalApprovedSightings,
+            totalSpecies,
+            totalMunicipalities,
+            sightingsThisMonth
+        );
+
+        // Sightings by month (last 12 months)
+        var twelveMonthsAgo = DateTime.UtcNow.AddMonths(-11);
+        var startDate = new DateTime(twelveMonthsAgo.Year, twelveMonthsAgo.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var sightingsByMonth = await approvedSightings
+            .Where(s => s.ObservedAt >= startDate)
+            .GroupBy(s => new { s.ObservedAt.Year, s.ObservedAt.Month })
+            .Select(g => new SightingsByMonthDto(g.Key.Year, g.Key.Month, g.Count()))
+            .OrderBy(x => x.Year)
+            .ThenBy(x => x.Month)
+            .ToListAsync(cancellationToken);
+
+        // Species by category (fauna vs flora)
+        var speciesByCategory = await context.Species
+            .GroupBy(s => s.IsFauna)
+            .Select(g => new SpeciesByCategoryDto(
+                g.Key ? "Fauna" : "Flora",
+                g.Count()
+            ))
+            .ToListAsync(cancellationToken);
+
+        // Sightings by municipality (top 10)
+        var sightingsByMunicipality = await approvedSightings
+            .Where(s => s.MunicipalityId != null)
+            .GroupBy(s => new { s.MunicipalityId, s.Municipality!.Name })
+            .Select(g => new SightingsByMunicipalityDto(
+                g.Key.MunicipalityId!.Value,
+                g.Key.Name,
+                g.Count()
+            ))
+            .OrderByDescending(x => x.SightingsCount)
+            .Take(10)
+            .ToListAsync(cancellationToken);
+
+        // Top observed species (top 10)
+        var topSpecies = await approvedSightings
+            .Where(s => s.SpeciesId != null && s.Species != null)
+            .GroupBy(s => new
+            {
+                s.SpeciesId,
+                Name = s.Species!.CommonName.FirstOrDefault(c => c.Code == "en")
+                       ?? s.Species.CommonName.FirstOrDefault()
+            })
+            .Select(g => new TopSpeciesDto(
+                g.Key.SpeciesId!.Value,
+                g.Key.Name != null ? g.Key.Name.Value : "Unknown",
+                g.Count()
+            ))
+            .OrderByDescending(x => x.SightingsCount)
+            .Take(10)
+            .ToListAsync(cancellationToken);
+
+        return new PublicStatisticsDto(
+            overview,
+            sightingsByMonth,
+            speciesByCategory,
+            sightingsByMunicipality,
+            topSpecies
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new public `/statistics` page with interactive charts for wildlife data visualization
- Creates a `/api/statistics` endpoint that aggregates approved sighting data without requiring authentication
- Implements 5 chart visualizations using Blazor-ApexCharts: overview cards, sightings trend line, species category donut, top municipalities bar chart, and top species bar chart

## Changes Made
- **Charts Package**: Added `Blazor-ApexCharts` to the Client project
- **DTOs**: Created `StatisticsDto.cs` with records for overview, monthly trends, categories, municipalities, and top species
- **Repository**: Added `IStatisticsRepository` and `StatisticsRepository` with aggregate queries on approved sightings
- **API Endpoint**: Created `StatisticsEndpoints.cs` with public GET `/api/statistics`
- **HTTP Client**: Extended `IWildlifeHttpClient` with `GetPublicStatisticsAsync()` method
- **UI Page**: Created `Statistics.razor` with responsive chart layout using MudBlazor
- **Localization**: Added all statistics-related keys in English and Spanish
- **Navigation**: Added Statistics link to both desktop and mobile navigation menus

## Test plan
- [ ] Navigate to `/statistics` page without authentication
- [ ] Verify overview cards display correct counts
- [ ] Verify all charts render correctly with data
- [ ] Test responsive layout on mobile viewports
- [ ] Test language toggle (English/Spanish) on statistics page
- [ ] Verify loading states and error handling

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)