### PR TITLE
Fix: ApexCharts 4.0 breaking changes and Aspire CLI install

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -32,7 +32,7 @@ jobs:
           dotnet-version: 10.x
 
       - name: Install Aspire CLI
-        run: dotnet tool install -g aspire.cli
+        run: dotnet tool install -g aspire.cli --prerelease
 
       - name: Log in with Azure CLI (Federated Credentials)
         uses: azure/login@v2

--- a/src/FaunaFinder.Client/FaunaFinder.Client.csproj
+++ b/src/FaunaFinder.Client/FaunaFinder.Client.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageReference Include="BlazingSingularity" Version="1.0.0-beta.3" />
     <PackageReference Include="MudBlazor" Version="8.4.0" />
-    <PackageReference Include="Blazor-ApexCharts" Version="3.7.1" />
+    <PackageReference Include="Blazor-ApexCharts" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\FaunaFinder.i18n.Contracts\FaunaFinder.i18n.Contracts.csproj" />

--- a/src/FaunaFinder.Client/_Imports.razor
+++ b/src/FaunaFinder.Client/_Imports.razor
@@ -23,3 +23,6 @@
 @using BlazingSingularity.Commands
 @using MudBlazor
 @using ApexCharts
+@using Color = MudBlazor.Color
+@using Size = MudBlazor.Size
+@using Align = MudBlazor.Align


### PR DESCRIPTION
## Summary
- Add `--prerelease` flag to Aspire CLI install (package not yet in stable NuGet feed)
- Resolve type ambiguity between `ApexCharts` and `MudBlazor` for `Color`, `Size`, `Align`
- Update Blazor-ApexCharts package from 3.7.1 to 4.0.0

## Changes
- `.github/workflows/azure-dev.yml`: Restore `--prerelease` flag
- `_Imports.razor`: Add using aliases to prefer MudBlazor types
- `FaunaFinder.Client.csproj`: Update ApexCharts to 4.0.0

## Test plan
- [x] `dotnet build src/FaunaFinder.Server` passes with 0 warnings/errors
- [ ] GitHub Actions workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)