### PR TITLE
Fix: Add AzureContainerAppEnvironment for Container App Jobs

### DIFF
--- a/src/FaunaFinder.AppHost/Program.cs
+++ b/src/FaunaFinder.AppHost/Program.cs
@@ -5,6 +5,9 @@ using Microsoft.Extensions.Logging;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+// Azure Container App Environment (required for PublishAsAzureContainerAppJob)
+builder.AddAzureContainerAppEnvironment("aca-env");
+
 var postgres = builder
     .AddAzurePostgresFlexibleServer("postgres")
     .RunAsContainer(c => c


### PR DESCRIPTION
## Summary
Add `AddAzureContainerAppEnvironment()` call required when using `PublishAsAzureContainerAppJob()`.

## Problem
```
Resource 'seeder' is configured to publish as an Azure Container App, but there are no 
'AzureContainerAppEnvironmentResource' resources. Ensure you have added one by calling 
'AddAzureContainerAppEnvironment'.
```

## Solution
Register the ACA environment before using `PublishAsAzureContainerAppJob()`:
```csharp
builder.AddAzureContainerAppEnvironment("aca-env");
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)