### PR TITLE
Fix: Add Azure config env vars for Aspire CLI

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -43,4 +43,8 @@ jobs:
 
       - name: Deploy with Aspire Pipelines
         run: aspire do deploy --project src/FaunaFinder.AppHost --environment Production
+        env:
+          Azure__SubscriptionId: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          Azure__Location: ${{ vars.AZURE_LOCATION }}
+          Azure__ResourceGroup: ${{ vars.AZURE_RESOURCE_GROUP }}
         


### PR DESCRIPTION
## Summary
Add Azure configuration environment variables in the format expected by Aspire CLI.

## Problem
```
An Azure subscription id is required. Set the Azure:SubscriptionId configuration value.
```

## Solution
Aspire CLI expects double-underscore format for nested configuration:
- `Azure__SubscriptionId`
- `Azure__Location`
- `Azure__ResourceGroup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)