### PR TITLE
Chore: Disable Aspire CLI telemetry in CI/CD

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -22,6 +22,7 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
       AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+      ASPIRE_CLI_TELEMETRY_OPTOUT: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Set ASPIRE_CLI_TELEMETRY_OPTOUT=1 to disable telemetry collection in CI/CD pipeline.