### PR TITLE
Add client-side caching for municipalities list

### DIFF
--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/MunicipalityHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/MunicipalityHttpClient.cs
@@ -6,15 +6,23 @@ namespace FaunaFinder.Wildlife.Application.Client;
 
 public sealed class MunicipalityHttpClient(HttpClient httpClient) : IMunicipalityHttpClient
 {
+    private IReadOnlyList<MunicipalityForListDto>? _cachedMunicipalities;
+
     public async Task<IReadOnlyList<MunicipalityForListDto>> GetAllMunicipalitiesAsync(
         CancellationToken cancellationToken = default
     )
     {
+        if (_cachedMunicipalities is not null)
+        {
+            return _cachedMunicipalities;
+        }
+
         var result = await httpClient.GetFromJsonAsync<IReadOnlyList<MunicipalityForListDto>>(
             "api/municipalities",
             cancellationToken
         );
-        return result ?? [];
+        _cachedMunicipalities = result ?? [];
+        return _cachedMunicipalities;
     }
 
     public async Task<MunicipalityForDetailDto?> GetMunicipalityDetailAsync(


### PR DESCRIPTION
## Summary
- Cache municipalities list in `MunicipalityHttpClient` to avoid redundant API calls
- Municipalities are static data that doesn't change during a session

## Changes
- Added `_cachedMunicipalities` field to store fetched municipalities
- `GetAllMunicipalitiesAsync` returns cached data on subsequent calls

## Test plan
- [ ] Navigate to Home page (uses municipalities for map)
- [ ] Verify municipalities load correctly on first visit
- [ ] Navigate away and back - should use cached data (no network request)