### PR TITLE
Statistics: Show species by category instead of Flora/Fauna

### DIFF
--- a/src/FaunaFinder.Client/Pages/Statistics.razor
+++ b/src/FaunaFinder.Client/Pages/Statistics.razor
@@ -60,7 +60,7 @@
             Background = "transparent"
         },
         Labels = _statistics?.SpeciesByCategory.Select(x => x.Category).ToList(),
-        Colors = ["#4caf50", "#2196f3"]
+        Colors = ["#4caf50", "#2196f3", "#ff9800", "#9c27b0", "#f44336", "#00bcd4", "#795548", "#607d8b", "#e91e63", "#3f51b5"]
     };
 
     private ApexChartOptions<SightingsByMunicipalityDto> GetBarChartOptions() => new()

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/StatisticsRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/StatisticsRepository.cs
@@ -52,14 +52,29 @@ public sealed class StatisticsRepository(IDbContextFactory<WildlifeDbContext> co
             .Select(x => new SightingsByMonthDto(x.Year, x.Month, x.Count))
             .ToList();
 
-        // Species by category (fauna vs flora)
-        var speciesByCategoryData = await context.Species
-            .GroupBy(s => s.IsFauna)
-            .Select(g => new { g.Key, Count = g.Count() })
+        // Species by category
+        var speciesByCategoryData = await context.SpeciesCategoryLinks
+            .GroupBy(scl => scl.CategoryId)
+            .Select(g => new { CategoryId = g.Key, Count = g.Count() })
             .ToListAsync(cancellationToken);
 
+        var categoryIds = speciesByCategoryData.Select(x => x.CategoryId).ToList();
+        var categories = await context.SpeciesCategories
+            .Where(c => categoryIds.Contains(c.Id))
+            .Select(c => new { c.Id, Name = c.Name.ToList() })
+            .ToListAsync(cancellationToken);
+
+        var categoryNameLookup = categories.ToDictionary(
+            x => x.Id,
+            x => x.Name.FirstOrDefault(n => n.Code == "en")?.Value
+                 ?? x.Name.FirstOrDefault()?.Value
+                 ?? "Unknown");
+
         var speciesByCategory = speciesByCategoryData
-            .Select(x => new SpeciesByCategoryDto(x.Key ? "Fauna" : "Flora", x.Count))
+            .Select(x => new SpeciesByCategoryDto(
+                categoryNameLookup.GetValueOrDefault(x.CategoryId, "Unknown"),
+                x.Count))
+            .OrderByDescending(x => x.Count)
             .ToList();
 
         // Sightings by municipality (top 10)


### PR DESCRIPTION
## Summary
- Replace Flora/Fauna pie chart with species count by category (birds, mammals, reptiles, plants, ferns, etc.)
- More informative breakdown of species distribution

## Changes
- Updated `StatisticsRepository` to group by `SpeciesCategoryLink` instead of `IsFauna`
- Query category names with proper localization (English fallback)
- Expanded pie chart color palette to support 10+ categories

## Test plan
- [ ] Navigate to Statistics page
- [ ] Verify pie chart shows species categories (not just Flora/Fauna)
- [ ] Verify category names are displayed correctly
- [ ] Verify colors are distinct for each category

Fixes #242