### PR TITLE
Fix mobile bottom sheet viewport height issue

### DIFF
--- a/src/FaunaFinder.Server/wwwroot/css/app.css
+++ b/src/FaunaFinder.Server/wwwroot/css/app.css
@@ -439,7 +439,8 @@ code {
     background: var(--mud-palette-surface);
     border-radius: 16px 16px 0 0;
     z-index: 101;
-    height: 90vh;
+    height: 90dvh;
+    max-height: 90vh; /* Fallback for browsers that don't support dvh */
     overflow-y: auto;
     transform: translateY(100%);
     transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
## Summary
- Use `dvh` (dynamic viewport height) instead of `vh` for mobile bottom sheet to account for browser UI elements
- This prevents the modal from being cut off when the mobile browser shows its navigation bar
- Includes `vh` fallback for browsers that don't support `dvh`

## Technical Details
The `100vh` unit doesn't account for mobile browser UI elements (address bar, bottom navigation). The `dvh` unit dynamically adjusts to the actual visible viewport, fixing the issue where modals get cut off.

## Test plan
- [ ] Test on mobile device with browser address bar visible
- [ ] Test on mobile device after scrolling (address bar hidden)
- [ ] Verify fallback works on older browsers