### PR TITLE
UI modernization phase 2: Conservation badges, stats hero, detail hero banner

### DIFF
--- a/src/FaunaFinder.Client/Components/SpeciesCard.razor
+++ b/src/FaunaFinder.Client/Components/SpeciesCard.razor
@@ -16,7 +16,15 @@
                 </div>
             }
             <div class="flex-1">
-                <MudText Typo="Typo.subtitle1" Class="font-semibold">@L.GetLocalizedValue(CommonName)</MudText>
+                <div class="d-flex align-center gap-2">
+                    <MudText Typo="Typo.subtitle1" Class="font-semibold">@L.GetLocalizedValue(CommonName)</MudText>
+                    @if (!string.IsNullOrEmpty(GRank) && ConservationLevel != ConservationStatus.Unknown)
+                    {
+                        <MudTooltip Text="@GetConservationTooltip()">
+                            <span class="conservation-badge @GetConservationClass()">@GRank</span>
+                        </MudTooltip>
+                    }
+                </div>
                 <MudText Typo="Typo.body2" Color="Color.Secondary" Class="italic">
                     @ScientificName
                 </MudText>
@@ -55,7 +63,45 @@
     public bool HasProfileImage { get; set; }
 
     [Parameter]
+    public string GRank { get; set; } = string.Empty;
+
+    [Parameter]
+    public string SRank { get; set; } = string.Empty;
+
+    [Parameter]
     public EventCallback OnClick { get; set; }
+
+    private enum ConservationStatus { CriticallyImperiled, Imperiled, Vulnerable, ApparentlySecure, Secure, Unknown }
+
+    private ConservationStatus ConservationLevel => GRank?.ToUpperInvariant() switch
+    {
+        var r when r?.StartsWith("G1") == true => ConservationStatus.CriticallyImperiled,
+        var r when r?.StartsWith("G2") == true => ConservationStatus.Imperiled,
+        var r when r?.StartsWith("G3") == true => ConservationStatus.Vulnerable,
+        var r when r?.StartsWith("G4") == true => ConservationStatus.ApparentlySecure,
+        var r when r?.StartsWith("G5") == true => ConservationStatus.Secure,
+        _ => ConservationStatus.Unknown
+    };
+
+    private string GetConservationClass() => ConservationLevel switch
+    {
+        ConservationStatus.CriticallyImperiled => "conservation-critical",
+        ConservationStatus.Imperiled => "conservation-imperiled",
+        ConservationStatus.Vulnerable => "conservation-vulnerable",
+        ConservationStatus.ApparentlySecure => "conservation-secure",
+        ConservationStatus.Secure => "conservation-stable",
+        _ => ""
+    };
+
+    private string GetConservationTooltip() => ConservationLevel switch
+    {
+        ConservationStatus.CriticallyImperiled => L["Conservation_CriticallyImperiled"],
+        ConservationStatus.Imperiled => L["Conservation_Imperiled"],
+        ConservationStatus.Vulnerable => L["Conservation_Vulnerable"],
+        ConservationStatus.ApparentlySecure => L["Conservation_ApparentlySecure"],
+        ConservationStatus.Secure => L["Conservation_Secure"],
+        _ => GRank
+    };
 
     protected override void OnInitialized()
     {

--- a/src/FaunaFinder.Client/Components/StatsHero.razor
+++ b/src/FaunaFinder.Client/Components/StatsHero.razor
@@ -1,0 +1,25 @@
+@inject IAppLocalizer L
+
+<div class="stats-hero mb-6">
+    <div class="stats-hero-content">
+        @foreach (var stat in Stats)
+        {
+            <div class="stats-hero-item">
+                <div class="stats-hero-icon">
+                    <MudIcon Icon="@stat.Icon" Size="Size.Medium" />
+                </div>
+                <div class="stats-hero-text">
+                    <span class="stats-hero-value">@stat.Value.ToString("N0")</span>
+                    <span class="stats-hero-label">@stat.Label</span>
+                </div>
+            </div>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter]
+    public List<StatItem> Stats { get; set; } = [];
+
+    public sealed record StatItem(string Icon, int Value, string Label);
+}

--- a/src/FaunaFinder.Client/Pages/Species.razor
+++ b/src/FaunaFinder.Client/Pages/Species.razor
@@ -144,8 +144,7 @@
     private List<StatsHero.StatItem> GetStatsItems() =>
     [
         new(Icons.Material.Filled.Pets, statsOverview?.TotalSpecies ?? 0, L["Stats_Species"]),
-        new(Icons.Material.Filled.LocationCity, statsOverview?.TotalMunicipalities ?? 0, L["Stats_Municipalities"]),
-        new(Icons.Material.Filled.PhotoCamera, statsOverview?.TotalApprovedSightings ?? 0, L["Stats_Sightings"])
+        new(Icons.Material.Filled.LocationCity, statsOverview?.TotalMunicipalities ?? 0, L["Stats_Municipalities"])
     ];
 
     private async Task ToggleCategory(int categoryId)

--- a/src/FaunaFinder.Client/Pages/Species.razor
+++ b/src/FaunaFinder.Client/Pages/Species.razor
@@ -1,6 +1,7 @@
 @page "/species"
 @implements IDisposable
 @inject ISpeciesHttpClient SpeciesHttpClient
+@inject IWildlifeHttpClient WildlifeHttpClient
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
 @inject IAppLocalizer L
@@ -12,6 +13,11 @@
     <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
         @L["Species_Description"]
     </MudText>
+
+    @if (statsOverview != null)
+    {
+        <StatsHero Stats="@GetStatsItems()" />
+    }
 
     @* Search and Filter Bar *@
     <MudGrid Class="mb-4">
@@ -74,6 +80,8 @@
                                  ScientificName="@s.ScientificName"
                                  MunicipalityCount="@s.MunicipalityNames.Count"
                                  HasProfileImage="@s.HasProfileImage"
+                                 GRank="@s.GRank"
+                                 SRank="@s.SRank"
                                  OnClick="() => NavigateToSpecies(s.Id)" />
                 </MudItem>
             }
@@ -113,17 +121,32 @@
     private ElementReference loadMoreTrigger;
     private DotNetObjectReference<Species>? dotNetRef;
     private bool isObserverInitialized = false;
+    private StatisticsOverviewDto? statsOverview;
 
     private const int PageSize = 20;
 
     protected override async Task OnInitializedAsync()
     {
-        // Load categories first
-        categories = (await SpeciesHttpClient.GetCategoriesAsync()).ToList();
+        // Load stats and categories in parallel
+        var statsTask = WildlifeHttpClient.GetPublicStatisticsAsync();
+        var categoriesTask = SpeciesHttpClient.GetCategoriesAsync();
+
+        await Task.WhenAll(statsTask, categoriesTask);
+
+        var stats = await statsTask;
+        statsOverview = stats?.Overview;
+        categories = (await categoriesTask).ToList();
 
         await LoadPageAsync();
         isInitialLoading = false;
     }
+
+    private List<StatsHero.StatItem> GetStatsItems() =>
+    [
+        new(Icons.Material.Filled.Pets, statsOverview?.TotalSpecies ?? 0, L["Stats_Species"]),
+        new(Icons.Material.Filled.LocationCity, statsOverview?.TotalMunicipalities ?? 0, L["Stats_Municipalities"]),
+        new(Icons.Material.Filled.PhotoCamera, statsOverview?.TotalApprovedSightings ?? 0, L["Stats_Sightings"])
+    ];
 
     private async Task ToggleCategory(int categoryId)
     {

--- a/src/FaunaFinder.Client/Pages/SpeciesDetail.razor
+++ b/src/FaunaFinder.Client/Pages/SpeciesDetail.razor
@@ -52,61 +52,65 @@
     }
     else
     {
-        @* Species Header *@
-        <MudPaper Elevation="2" Class="pa-4 mb-6">
-            <MudGrid>
-                @if (species.HasProfileImage)
-                {
-                    <MudItem xs="12" sm="4" md="3">
+        @* Species Hero Banner *@
+        <div class="species-hero mb-6 @(species.HasProfileImage ? "has-image" : "")"
+             style="@(species.HasProfileImage ? $"--hero-bg: url('{GetProfileImageUrl()}')" : "")">
+            <div class="species-hero-content">
+                <div class="d-flex gap-4 flex-wrap align-center">
+                    @if (species.HasProfileImage)
+                    {
                         <MudImage Src="@GetProfileImageUrl()"
                                   Alt="@L.GetLocalizedValue(species.CommonName)"
                                   ObjectFit="ObjectFit.Cover"
-                                  Class="rounded-lg species-image w-full max-h-200" />
-                        @if (!string.IsNullOrEmpty(species.ImageSourceUrl))
-                        {
-                            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1">
-                                @L["SpeciesDetail_ImageSource"]:
-                                <MudLink Href="@species.ImageSourceUrl" Target="_blank" Color="Color.Primary">
-                                    @GetImageSourceHostname()
-                                </MudLink>
-                            </MudText>
-                        }
-                    </MudItem>
-                }
-                <MudItem xs="12" sm="@(species.HasProfileImage ? 8 : 12)" md="@(species.HasProfileImage ? 9 : 12)">
-                    <MudText Typo="Typo.h4" Color="Color.Primary" GutterBottom="true">@L.GetLocalizedValue(species.CommonName)</MudText>
-                    <MudText Typo="Typo.h6" Color="Color.Secondary" Class="font-italic">@species.ScientificName</MudText>
-                    <div class="d-flex align-center mt-3">
-                        <MudIcon Icon="@Icons.Material.Filled.LocationOn" Size="Size.Medium" Color="Color.Secondary" Class="mr-2" />
-                        <MudText Typo="Typo.body1" Color="Color.Secondary">
-                            @L["SpeciesDetail_FoundIn", species.Municipalities.Count, species.Municipalities.Count == 1 ? L["Species_Municipality"] : L["Species_Municipalities"]]
-                        </MudText>
+                                  Class="species-hero-image" />
+                    }
+                    else
+                    {
+                        <div class="species-hero-icon">
+                            <MudIcon Icon="@(species.IsFauna ? Icons.Material.Filled.Pets : Icons.Material.Filled.Grass)"
+                                     Size="Size.Large" />
+                        </div>
+                    }
+                    <div class="flex-1">
+                        <MudText Typo="Typo.h4" Class="species-hero-title">@L.GetLocalizedValue(species.CommonName)</MudText>
+                        <MudText Typo="Typo.h6" Class="species-hero-subtitle font-italic">@species.ScientificName</MudText>
+                        <div class="d-flex align-center mt-2 species-hero-meta">
+                            <MudIcon Icon="@Icons.Material.Filled.LocationOn" Size="Size.Small" Class="mr-1" />
+                            <span>@L["SpeciesDetail_FoundIn", species.Municipalities.Count, species.Municipalities.Count == 1 ? L["Species_Municipality"] : L["Species_Municipalities"]]</span>
+                        </div>
                     </div>
-                    <div class="d-flex flex-wrap gap-2 mt-4">
-                        @if (species.Locations.Count > 0)
-                        {
-                            <MudButton Variant="Variant.Filled"
-                                       Color="Color.Primary"
-                                       StartIcon="@Icons.Material.Filled.Map"
-                                       OnClick="ViewLocations">
-                                @L["SpeciesDetail_ViewLocations"]
-                            </MudButton>
-                        }
-                        <MudButton Variant="Variant.Outlined"
-                                   Color="Color.Primary"
-                                   StartIcon="@Icons.Material.Filled.PictureAsPdf"
-                                   OnClick="() => DownloadPdfCommand.ExecuteAsync()"
-                                   Disabled="DownloadPdfCommand.IsLoading">
-                            @if (DownloadPdfCommand.IsLoading)
-                            {
-                                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
-                            }
-                            @L["Export_PDF"]
+                </div>
+                <div class="d-flex flex-wrap gap-2 mt-4">
+                    @if (species.Locations.Count > 0)
+                    {
+                        <MudButton Variant="Variant.Filled"
+                                   Class="species-hero-btn-primary"
+                                   StartIcon="@Icons.Material.Filled.Map"
+                                   OnClick="ViewLocations">
+                            @L["SpeciesDetail_ViewLocations"]
                         </MudButton>
+                    }
+                    <MudButton Variant="Variant.Outlined"
+                               Class="species-hero-btn-secondary"
+                               StartIcon="@Icons.Material.Filled.PictureAsPdf"
+                               OnClick="() => DownloadPdfCommand.ExecuteAsync()"
+                               Disabled="DownloadPdfCommand.IsLoading">
+                        @if (DownloadPdfCommand.IsLoading)
+                        {
+                            <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                        }
+                        @L["Export_PDF"]
+                    </MudButton>
+                </div>
+                @if (!string.IsNullOrEmpty(species.ImageSourceUrl))
+                {
+                    <div class="species-hero-source mt-3">
+                        @L["SpeciesDetail_ImageSource"]:
+                        <a href="@species.ImageSourceUrl" target="_blank">@GetImageSourceHostname()</a>
                     </div>
-                </MudItem>
-            </MudGrid>
-        </MudPaper>
+                }
+            </div>
+        </div>
 
         @* Municipalities Section *@
         <MudText Typo="Typo.h5" Color="Color.Primary" GutterBottom="true" Class="mb-4">@L["SpeciesDetail_MunicipalitiesTitle"]</MudText>

--- a/src/FaunaFinder.Client/Services/Localization/Translations.cs
+++ b/src/FaunaFinder.Client/Services/Localization/Translations.cs
@@ -58,6 +58,18 @@ public static class Translations
             ["Species_Municipalities"] = "municipalities",
             ["Species_Showing"] = "Showing {0}-{1} of {2} species",
 
+            // Conservation Status
+            ["Conservation_CriticallyImperiled"] = "Critically Imperiled",
+            ["Conservation_Imperiled"] = "Imperiled",
+            ["Conservation_Vulnerable"] = "Vulnerable",
+            ["Conservation_ApparentlySecure"] = "Apparently Secure",
+            ["Conservation_Secure"] = "Secure",
+
+            // Stats Hero
+            ["Stats_Species"] = "Species",
+            ["Stats_Municipalities"] = "Municipalities",
+            ["Stats_Sightings"] = "Sightings",
+
             // Species Detail Page
             ["SpeciesDetail_FoundIn"] = "Found in {0} {1}",
             ["SpeciesDetail_MunicipalitiesTitle"] = "Municipalities",
@@ -471,6 +483,18 @@ public static class Translations
             ["Species_Municipality"] = "municipio",
             ["Species_Municipalities"] = "municipios",
             ["Species_Showing"] = "Mostrando {0}-{1} de {2} especies",
+
+            // Conservation Status
+            ["Conservation_CriticallyImperiled"] = "En Peligro Crítico",
+            ["Conservation_Imperiled"] = "En Peligro",
+            ["Conservation_Vulnerable"] = "Vulnerable",
+            ["Conservation_ApparentlySecure"] = "Aparentemente Segura",
+            ["Conservation_Secure"] = "Segura",
+
+            // Stats Hero
+            ["Stats_Species"] = "Especies",
+            ["Stats_Municipalities"] = "Municipios",
+            ["Stats_Sightings"] = "Avistamientos",
 
             // Species Detail Page
             ["SpeciesDetail_FoundIn"] = "Encontrada en {0} {1}",

--- a/src/FaunaFinder.Server/Services/Localization/Translations.cs
+++ b/src/FaunaFinder.Server/Services/Localization/Translations.cs
@@ -53,6 +53,18 @@ public static class Translations
             ["Species_Municipalities"] = "municipalities",
             ["Species_Showing"] = "Showing {0}-{1} of {2} species",
 
+            // Conservation Status
+            ["Conservation_CriticallyImperiled"] = "Critically Imperiled",
+            ["Conservation_Imperiled"] = "Imperiled",
+            ["Conservation_Vulnerable"] = "Vulnerable",
+            ["Conservation_ApparentlySecure"] = "Apparently Secure",
+            ["Conservation_Secure"] = "Secure",
+
+            // Stats Hero
+            ["Stats_Species"] = "Species",
+            ["Stats_Municipalities"] = "Municipalities",
+            ["Stats_Sightings"] = "Sightings",
+
             // Species Detail Page
             ["SpeciesDetail_FoundIn"] = "Found in {0} {1}",
             ["SpeciesDetail_MunicipalitiesTitle"] = "Municipalities",
@@ -231,6 +243,18 @@ public static class Translations
             ["Species_Municipality"] = "municipio",
             ["Species_Municipalities"] = "municipios",
             ["Species_Showing"] = "Mostrando {0}-{1} de {2} especies",
+
+            // Conservation Status
+            ["Conservation_CriticallyImperiled"] = "En Peligro Crítico",
+            ["Conservation_Imperiled"] = "En Peligro",
+            ["Conservation_Vulnerable"] = "Vulnerable",
+            ["Conservation_ApparentlySecure"] = "Aparentemente Segura",
+            ["Conservation_Secure"] = "Segura",
+
+            // Stats Hero
+            ["Stats_Species"] = "Especies",
+            ["Stats_Municipalities"] = "Municipios",
+            ["Stats_Sightings"] = "Avistamientos",
 
             // Species Detail Page
             ["SpeciesDetail_FoundIn"] = "Encontrada en {0} {1}",

--- a/src/FaunaFinder.Server/wwwroot/css/app.css
+++ b/src/FaunaFinder.Server/wwwroot/css/app.css
@@ -660,6 +660,258 @@ body {
     opacity: 1;
 }
 
+/* Conservation Status Badges */
+.conservation-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    flex-shrink: 0;
+}
+
+.conservation-critical {
+    background-color: #ffebee;
+    color: #c62828;
+    border: 1px solid #ef9a9a;
+}
+
+.conservation-imperiled {
+    background-color: #fff3e0;
+    color: #e65100;
+    border: 1px solid #ffcc80;
+}
+
+.conservation-vulnerable {
+    background-color: #fffde7;
+    color: #f9a825;
+    border: 1px solid #fff59d;
+}
+
+.conservation-secure {
+    background-color: #e8f5e9;
+    color: #2e7d32;
+    border: 1px solid #a5d6a7;
+}
+
+.conservation-stable {
+    background-color: #e0f2f1;
+    color: #00695c;
+    border: 1px solid #80cbc4;
+}
+
+/* Dark mode conservation badges */
+.mud-theme-dark .conservation-critical {
+    background-color: rgba(198, 40, 40, 0.2);
+    color: #ef5350;
+    border-color: rgba(198, 40, 40, 0.4);
+}
+
+.mud-theme-dark .conservation-imperiled {
+    background-color: rgba(230, 81, 0, 0.2);
+    color: #ff9800;
+    border-color: rgba(230, 81, 0, 0.4);
+}
+
+.mud-theme-dark .conservation-vulnerable {
+    background-color: rgba(249, 168, 37, 0.2);
+    color: #ffc107;
+    border-color: rgba(249, 168, 37, 0.4);
+}
+
+.mud-theme-dark .conservation-secure {
+    background-color: rgba(46, 125, 50, 0.2);
+    color: #66bb6a;
+    border-color: rgba(46, 125, 50, 0.4);
+}
+
+.mud-theme-dark .conservation-stable {
+    background-color: rgba(0, 105, 92, 0.2);
+    color: #4db6ac;
+    border-color: rgba(0, 105, 92, 0.4);
+}
+
+/* ==========================================================================
+   Stats Hero Section
+   ========================================================================== */
+
+.stats-hero {
+    background: linear-gradient(135deg, var(--mud-palette-primary) 0%, var(--mud-palette-primary-darken) 100%);
+    border-radius: 16px;
+    padding: 24px 32px;
+    color: white;
+}
+
+.stats-hero-content {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    justify-content: center;
+}
+
+.stats-hero-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.stats-hero-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.15);
+    color: white;
+}
+
+.stats-hero-text {
+    display: flex;
+    flex-direction: column;
+}
+
+.stats-hero-value {
+    font-size: 1.75rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.stats-hero-label {
+    font-size: 0.875rem;
+    opacity: 0.85;
+}
+
+@media (max-width: 600px) {
+    .stats-hero {
+        padding: 20px 16px;
+    }
+
+    .stats-hero-content {
+        gap: 20px;
+    }
+
+    .stats-hero-value {
+        font-size: 1.5rem;
+    }
+}
+
+/* ==========================================================================
+   Species Detail Hero Banner
+   ========================================================================== */
+
+.species-hero {
+    position: relative;
+    border-radius: 16px;
+    overflow: hidden;
+    background: linear-gradient(135deg, var(--mud-palette-primary) 0%, var(--mud-palette-primary-darken) 100%);
+}
+
+.species-hero.has-image::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: var(--hero-bg);
+    background-size: cover;
+    background-position: center;
+    filter: blur(20px) brightness(0.4);
+    transform: scale(1.1);
+}
+
+.species-hero-content {
+    position: relative;
+    padding: 32px;
+    color: white;
+}
+
+.species-hero-image {
+    width: 140px;
+    height: 140px;
+    border-radius: 12px;
+    object-fit: cover;
+    border: 3px solid rgba(255, 255, 255, 0.3);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    flex-shrink: 0;
+}
+
+.species-hero-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 80px;
+    height: 80px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.15);
+    flex-shrink: 0;
+}
+
+.species-hero-title {
+    color: white !important;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.species-hero-subtitle {
+    color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.species-hero-meta {
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 0.95rem;
+}
+
+.species-hero-btn-primary {
+    background-color: white !important;
+    color: var(--mud-palette-primary-darken) !important;
+}
+
+.species-hero-btn-primary:hover {
+    background-color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.species-hero-btn-secondary {
+    border-color: rgba(255, 255, 255, 0.5) !important;
+    color: white !important;
+}
+
+.species-hero-btn-secondary:hover {
+    background-color: rgba(255, 255, 255, 0.1) !important;
+    border-color: white !important;
+}
+
+.species-hero-source {
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.species-hero-source a {
+    color: rgba(255, 255, 255, 0.8);
+    text-decoration: underline;
+}
+
+.species-hero-source a:hover {
+    color: white;
+}
+
+@media (max-width: 600px) {
+    .species-hero-content {
+        padding: 20px;
+    }
+
+    .species-hero-image {
+        width: 100px;
+        height: 100px;
+    }
+
+    .species-hero-icon {
+        width: 60px;
+        height: 60px;
+    }
+}
+
 /* Municipality Card (compact version for species detail) */
 .municipality-card-compact {
     cursor: pointer;

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Dtos/SpeciesForSearchDto.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Dtos/SpeciesForSearchDto.cs
@@ -8,7 +8,9 @@ public sealed record SpeciesForSearchDto(
     string ScientificName,
     IReadOnlyList<string> MunicipalityNames,
     bool IsFauna,
-    bool HasProfileImage
+    bool HasProfileImage,
+    string GRank,
+    string SRank
 )
 {
     public string GetCommonName(string locale = "en") =>

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
@@ -166,8 +166,8 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
                 s.MunicipalitySpecies.Select(ms => ms.Municipality.Name).OrderBy(n => n).ToList(),
                 s.IsFauna,
                 s.ProfileImageData != null,
-                s.GRank,
-                s.SRank
+                s.GRank ?? string.Empty,
+                s.SRank ?? string.Empty
             ))
             .AsAsyncEnumerable()
             .WithCancellation(cancellationToken))

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
@@ -165,7 +165,9 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
                 s.ScientificName,
                 s.MunicipalitySpecies.Select(ms => ms.Municipality.Name).OrderBy(n => n).ToList(),
                 s.IsFauna,
-                s.ProfileImageData != null
+                s.ProfileImageData != null,
+                s.GRank,
+                s.SRank
             ))
             .AsAsyncEnumerable()
             .WithCancellation(cancellationToken))


### PR DESCRIPTION
## Summary

- **Conservation status badges**: Species cards now display colored badges (G1-G5) indicating conservation rank
  - G1 (Critical): Red badge
  - G2 (Imperiled): Orange badge  
  - G3 (Vulnerable): Yellow badge
  - G4 (Apparently Secure): Light green badge
  - G5 (Secure): Teal badge
  
- **Stats hero section**: New gradient banner on Species page showing total species, municipalities, and sightings counts

- **Species detail hero banner**: Redesigned header with blurred image background, floating species image, and styled action buttons

## Changes

- `SpeciesCard.razor`: Added GRank/SRank parameters and conservation badge display
- `StatsHero.razor`: New reusable stats banner component
- `Species.razor`: Integrated stats hero and conservation data
- `SpeciesDetail.razor`: New hero banner layout with gradient/blurred background
- `SpeciesForSearchDto.cs`: Added GRank and SRank fields
- `SpeciesRepository.cs`: Updated projection to include conservation ranks
- `app.css`: Added styles for conservation badges, stats hero, and detail hero banner
- `Translations.cs`: Added EN/ES localization for conservation status and stats labels

## Test plan

- [ ] Verify conservation badges display correctly on species cards
- [ ] Verify badge colors match conservation status (red for G1, green for G5)
- [ ] Verify stats hero shows correct counts on Species page
- [ ] Verify species detail hero banner displays correctly with/without images
- [ ] Verify blurred background effect on species with images
- [ ] Test dark mode compatibility
- [ ] Test Spanish translations