### PR TITLE
Add heatmap visualization for species density (#223)

### DIFF
--- a/src/FaunaFinder.Client/Pages/Home.razor
+++ b/src/FaunaFinder.Client/Pages/Home.razor
@@ -31,17 +31,29 @@
         <div id="map" class="map"></div>
     </div>
 
-    @* Desktop FAB for Draw Polygon when nothing selected *@
+    @* Desktop FABs for Draw Polygon and Heatmap when nothing selected *@
     <MudHidden Breakpoint="Breakpoint.SmAndDown">
         @if (clickedMunicipalityName == null && !showNearbySpecies && viewingSpeciesLocations == null && !isPolygonDrawMode)
         {
             <div class="desktop-fab-container">
-                <MudTooltip Text="@L["DrawPolygon_Tooltip"]" Placement="Placement.Left">
-                    <MudFab Color="Color.Tertiary"
-                            StartIcon="@Icons.Material.Filled.Pentagon"
-                            Size="Size.Large"
-                            OnClick="EnablePolygonDrawMode" />
-                </MudTooltip>
+                <MudStack Spacing="2">
+                    @if (!isHeatmapVisible)
+                    {
+                        <MudTooltip Text="@L["Heatmap_Tooltip"]" Placement="Placement.Left">
+                            <MudFab Color="Color.Error"
+                                    StartIcon="@Icons.Material.Filled.Whatshot"
+                                    Size="Size.Medium"
+                                    OnClick="ToggleHeatmap"
+                                    Disabled="isLoadingHeatmap" />
+                        </MudTooltip>
+                    }
+                    <MudTooltip Text="@L["DrawPolygon_Tooltip"]" Placement="Placement.Left">
+                        <MudFab Color="Color.Tertiary"
+                                StartIcon="@Icons.Material.Filled.Pentagon"
+                                Size="Size.Large"
+                                OnClick="EnablePolygonDrawMode" />
+                    </MudTooltip>
+                </MudStack>
             </div>
         }
     </MudHidden>
@@ -542,7 +554,7 @@
         }
     </MudHidden>
 
-    @* Mobile FAB for "Species Near Me" / "Draw Area" when nothing selected *@
+    @* Mobile FAB for "Species Near Me" / "Draw Area" / "Heatmap" when nothing selected *@
     <MudHidden Breakpoint="Breakpoint.MdAndUp">
         @if (clickedMunicipalityName == null && !showNearbySpecies && viewingSpeciesLocations == null && !isPolygonDrawMode)
         {
@@ -554,6 +566,15 @@
                             Label="@L["NearMe_Button"]"
                             Class="mobile-fab-item"
                             OnClick="OpenSpeciesNearMe" />
+                }
+                @if (!isHeatmapVisible)
+                {
+                    <MudFab Color="Color.Error"
+                            StartIcon="@Icons.Material.Filled.Whatshot"
+                            Label="@L["Heatmap_Toggle"]"
+                            Class="mobile-fab-item"
+                            OnClick="ToggleHeatmap"
+                            Disabled="isLoadingHeatmap" />
                 }
                 <MudFab Color="Color.Tertiary"
                         StartIcon="@Icons.Material.Filled.Pentagon"
@@ -660,6 +681,10 @@
     // Draw polygon search state
     private bool isPolygonDrawMode = false;
     private List<PolygonCoordinate>? drawnPolygonCoordinates;
+
+    // Heatmap state
+    private bool isHeatmapVisible = false;
+    private bool isLoadingHeatmap = false;
 
     private enum SortOption
     {
@@ -1329,6 +1354,60 @@
         [property: System.Text.Json.Serialization.JsonPropertyName("latitude")] double Latitude,
         [property: System.Text.Json.Serialization.JsonPropertyName("longitude")] double Longitude,
         [property: System.Text.Json.Serialization.JsonPropertyName("radiusKm")] int RadiusKm);
+
+    // Heatmap methods
+    private async Task ToggleHeatmap()
+    {
+        if (isHeatmapVisible)
+        {
+            await HideHeatmap();
+        }
+        else
+        {
+            await ShowHeatmap();
+        }
+    }
+
+    private async Task ShowHeatmap()
+    {
+        if (isLoadingHeatmap) return;
+
+        isLoadingHeatmap = true;
+        StateHasChanged();
+
+        try
+        {
+            var heatmapData = await SpeciesHttpClient.GetHeatmapDataAsync();
+            var points = heatmapData.Select(p => new HeatmapPointData(
+                p.Latitude,
+                p.Longitude,
+                p.Intensity,
+                p.IsFauna
+            ));
+
+            await MapService.ShowHeatmapAsync(points);
+            isHeatmapVisible = true;
+        }
+        finally
+        {
+            isLoadingHeatmap = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task HideHeatmap()
+    {
+        await MapService.HideHeatmapAsync();
+        isHeatmapVisible = false;
+        StateHasChanged();
+    }
+
+    [JSInvokable]
+    public void OnHeatmapClosed()
+    {
+        isHeatmapVisible = false;
+        StateHasChanged();
+    }
 
     public void Dispose()
     {

--- a/src/FaunaFinder.Client/Services/Localization/Translations.cs
+++ b/src/FaunaFinder.Client/Services/Localization/Translations.cs
@@ -167,6 +167,14 @@ public static class Translations
             ["DrawPolygon_Finish"] = "Finish",
             ["DrawPolygon_SpeciesFound"] = "{0} species found in selected area",
 
+            // Heatmap
+            ["Heatmap_Toggle"] = "Heatmap",
+            ["Heatmap_Tooltip"] = "Show species density heatmap",
+            ["Heatmap_Loading"] = "Loading heatmap data...",
+            ["Heatmap_FilterAll"] = "All",
+            ["Heatmap_FilterFauna"] = "Fauna",
+            ["Heatmap_FilterFlora"] = "Flora",
+
             // Export
             ["Export_Button"] = "Export",
             ["Export_PDF"] = "Download PDF",
@@ -594,6 +602,14 @@ public static class Translations
             ["DrawPolygon_Redraw"] = "Redibujar forma",
             ["DrawPolygon_Finish"] = "Terminar",
             ["DrawPolygon_SpeciesFound"] = "{0} especies encontradas en el area seleccionada",
+
+            // Heatmap
+            ["Heatmap_Toggle"] = "Mapa de calor",
+            ["Heatmap_Tooltip"] = "Mostrar mapa de calor de densidad de especies",
+            ["Heatmap_Loading"] = "Cargando datos del mapa de calor...",
+            ["Heatmap_FilterAll"] = "Todas",
+            ["Heatmap_FilterFauna"] = "Fauna",
+            ["Heatmap_FilterFlora"] = "Flora",
 
             // Export
             ["Export_Button"] = "Exportar",

--- a/src/FaunaFinder.Client/Services/Map/IMapService.cs
+++ b/src/FaunaFinder.Client/Services/Map/IMapService.cs
@@ -36,6 +36,11 @@ public interface IMapService
     // Municipality highlight methods
     Task HighlightMunicipalityAsync(string countyCode);
     Task FocusOnMunicipalityAsync(string countyCode);
+
+    // Heatmap methods
+    Task ShowHeatmapAsync(IEnumerable<HeatmapPointData> points);
+    Task HideHeatmapAsync();
+    Task SetHeatmapFilterAsync(string filter);
 }
 
 public record SpeciesLocationData(
@@ -81,4 +86,18 @@ public record JsNearbySpecies(
     [property: System.Text.Json.Serialization.JsonPropertyName("radiusMeters")] double RadiusMeters,
     [property: System.Text.Json.Serialization.JsonPropertyName("locationDescription")]
         string? LocationDescription
+);
+
+public record HeatmapPointData(
+    double Latitude,
+    double Longitude,
+    double Intensity,
+    bool IsFauna
+);
+
+public record JsHeatmapPoint(
+    [property: System.Text.Json.Serialization.JsonPropertyName("latitude")] double Latitude,
+    [property: System.Text.Json.Serialization.JsonPropertyName("longitude")] double Longitude,
+    [property: System.Text.Json.Serialization.JsonPropertyName("intensity")] double Intensity,
+    [property: System.Text.Json.Serialization.JsonPropertyName("isFauna")] bool IsFauna
 );

--- a/src/FaunaFinder.Client/Services/Map/MapService.cs
+++ b/src/FaunaFinder.Client/Services/Map/MapService.cs
@@ -181,4 +181,28 @@ public sealed class MapService : IMapService
     {
         await _js.InvokeVoidAsync("leafletInterop.focusOnMunicipality", countyCode);
     }
+
+    public async Task ShowHeatmapAsync(IEnumerable<HeatmapPointData> points)
+    {
+        var jsPoints = points
+            .Select(p => new JsHeatmapPoint(
+                p.Latitude,
+                p.Longitude,
+                p.Intensity,
+                p.IsFauna
+            ))
+            .ToArray();
+
+        await _js.InvokeVoidAsync("leafletInterop.showHeatmap", (object)jsPoints);
+    }
+
+    public async Task HideHeatmapAsync()
+    {
+        await _js.InvokeVoidAsync("leafletInterop.hideHeatmap");
+    }
+
+    public async Task SetHeatmapFilterAsync(string filter)
+    {
+        await _js.InvokeVoidAsync("leafletInterop.setHeatmapFilter", filter);
+    }
 }

--- a/src/FaunaFinder.Server/Components/App.razor
+++ b/src/FaunaFinder.Server/Components/App.razor
@@ -66,6 +66,7 @@
     </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script src="https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js"></script>
     <script src="js/leafletInterop.js"></script>
     <script src="js/infiniteScrollInterop.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>

--- a/src/FaunaFinder.Server/Endpoints/SpeciesEndpoints.cs
+++ b/src/FaunaFinder.Server/Endpoints/SpeciesEndpoints.cs
@@ -18,6 +18,7 @@ public static class SpeciesEndpoints
         group.MapGet("/nearby", GetSpeciesNearby).WithName("GetSpeciesNearby");
         group.MapPost("/in-polygon", GetSpeciesInPolygon).WithName("GetSpeciesInPolygon");
         group.MapGet("/categories", GetCategories).WithName("GetCategories");
+        group.MapGet("/heatmap", GetHeatmapData).WithName("GetHeatmapData");
     }
 
     private static IAsyncEnumerable<SpeciesForSearchDto> GetSpecies(
@@ -83,5 +84,13 @@ public static class SpeciesEndpoints
     {
         var categories = await repository.GetAllCategoriesAsync(ct);
         return TypedResults.Ok(categories);
+    }
+
+    private static async Task<Ok<IReadOnlyList<HeatmapPointDto>>> GetHeatmapData(
+        ISpeciesRepository repository,
+        CancellationToken ct)
+    {
+        var heatmapData = await repository.GetHeatmapDataAsync(ct);
+        return TypedResults.Ok(heatmapData);
     }
 }

--- a/src/FaunaFinder.Server/Services/Localization/Translations.cs
+++ b/src/FaunaFinder.Server/Services/Localization/Translations.cs
@@ -158,6 +158,14 @@ public static class Translations
             ["DrawPolygon_Finish"] = "Finish",
             ["DrawPolygon_SpeciesFound"] = "{0} species found in selected area",
 
+            // Heatmap
+            ["Heatmap_Toggle"] = "Heatmap",
+            ["Heatmap_Tooltip"] = "Show species density heatmap",
+            ["Heatmap_Loading"] = "Loading heatmap data...",
+            ["Heatmap_FilterAll"] = "All",
+            ["Heatmap_FilterFauna"] = "Fauna",
+            ["Heatmap_FilterFlora"] = "Flora",
+
             // Export
             ["Export_Button"] = "Export",
             ["Export_PDF"] = "Download PDF",
@@ -349,6 +357,14 @@ public static class Translations
             ["DrawPolygon_Redraw"] = "Redibujar forma",
             ["DrawPolygon_Finish"] = "Terminar",
             ["DrawPolygon_SpeciesFound"] = "{0} especies encontradas en el area seleccionada",
+
+            // Heatmap
+            ["Heatmap_Toggle"] = "Mapa de calor",
+            ["Heatmap_Tooltip"] = "Mostrar mapa de calor de densidad de especies",
+            ["Heatmap_Loading"] = "Cargando datos del mapa de calor...",
+            ["Heatmap_FilterAll"] = "Todas",
+            ["Heatmap_FilterFauna"] = "Fauna",
+            ["Heatmap_FilterFlora"] = "Flora",
 
             // Export
             ["Export_Button"] = "Exportar",

--- a/src/FaunaFinder.Server/wwwroot/css/app.css
+++ b/src/FaunaFinder.Server/wwwroot/css/app.css
@@ -1201,3 +1201,153 @@ body {
         transition-duration: 0.01ms !important;
     }
 }
+
+/* ============================================================================
+   Heatmap Control Styles
+   ============================================================================ */
+
+.leaflet-control-heatmap {
+    background: white;
+    border-radius: 4px;
+    box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+    overflow: hidden;
+}
+
+.mud-theme-dark .leaflet-control-heatmap {
+    background: #424242;
+}
+
+.heatmap-control-content {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    min-width: 160px;
+}
+
+.heatmap-control-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #333;
+    white-space: nowrap;
+}
+
+.mud-theme-dark .heatmap-control-title {
+    color: #fff;
+}
+
+.heatmap-control-title svg {
+    color: #ef4444;
+}
+
+.heatmap-filter-buttons {
+    display: flex;
+    gap: 4px;
+}
+
+.heatmap-filter-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    height: 28px;
+    padding: 4px 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: #f5f5f5;
+    color: #666;
+    font-size: 11px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.mud-theme-dark .heatmap-filter-btn {
+    background: #333;
+    border-color: #555;
+    color: #ccc;
+}
+
+.heatmap-filter-btn:hover {
+    background: #e0e0e0;
+    border-color: #bbb;
+}
+
+.mud-theme-dark .heatmap-filter-btn:hover {
+    background: #444;
+    border-color: #666;
+}
+
+.heatmap-filter-btn.active {
+    background: #ef4444;
+    border-color: #ef4444;
+    color: white;
+}
+
+.heatmap-filter-btn.active:hover {
+    background: #dc2626;
+    border-color: #dc2626;
+}
+
+.heatmap-filter-btn[data-filter="fauna"].active {
+    background: #f97316;
+    border-color: #f97316;
+}
+
+.heatmap-filter-btn[data-filter="flora"].active {
+    background: #22c55e;
+    border-color: #22c55e;
+}
+
+.heatmap-close-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: #999;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.heatmap-close-btn:hover {
+    background: #f0f0f0;
+    color: #666;
+}
+
+.mud-theme-dark .heatmap-close-btn:hover {
+    background: #555;
+    color: #fff;
+}
+
+/* Heatmap toggle button (FAB style) */
+.heatmap-fab {
+    position: absolute;
+    top: 80px;
+    right: 10px;
+    z-index: 1000;
+}
+
+@media (max-width: 600px) {
+    .heatmap-control-content {
+        flex-wrap: wrap;
+        min-width: auto;
+        padding: 8px;
+    }
+
+    .heatmap-control-title {
+        flex: 1 0 100%;
+        margin-bottom: 4px;
+    }
+
+    .heatmap-filter-buttons {
+        flex: 1;
+    }
+}

--- a/src/FaunaFinder.Server/wwwroot/js/leafletInterop.js
+++ b/src/FaunaFinder.Server/wwwroot/js/leafletInterop.js
@@ -28,6 +28,10 @@ window.leafletInterop = {
     drawPolygonPoints: [],
     drawPolygonMarkers: [],
     drawPolygonPreviewLine: null,
+    heatmapLayer: null,
+    heatmapData: [],
+    heatmapFilter: 'all',
+    heatmapControl: null,
     lightTileUrl: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
     darkTileUrl: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
     lightTheme: {
@@ -983,6 +987,166 @@ window.leafletInterop = {
         this.drawPolygonMarkers = [];
         // Clear points
         this.drawPolygonPoints = [];
+    },
+    showHeatmap(points) {
+        if (!this.map)
+            return;
+        // Store the full heatmap data
+        this.heatmapData = points;
+        // Create heatmap control if it doesn't exist
+        if (!this.heatmapControl) {
+            this.createHeatmapControl();
+        }
+        // Update the heatmap layer with filtered data
+        this.updateHeatmapLayer();
+        // Show the heatmap control
+        if (this.heatmapControl) {
+            this.heatmapControl.style.display = '';
+        }
+        // Announce to screen readers
+        this.announceToScreenReader(`Heatmap enabled showing ${points.length} species locations.`);
+    },
+    hideHeatmap() {
+        if (!this.map)
+            return;
+        // Remove heatmap layer
+        if (this.heatmapLayer) {
+            this.map.removeLayer(this.heatmapLayer);
+            this.heatmapLayer = null;
+        }
+        // Clear data
+        this.heatmapData = [];
+        // Hide the heatmap control
+        if (this.heatmapControl) {
+            this.heatmapControl.style.display = 'none';
+        }
+        // Announce to screen readers
+        this.announceToScreenReader('Heatmap disabled.');
+    },
+    setHeatmapFilter(filter) {
+        this.heatmapFilter = filter;
+        this.updateHeatmapLayer();
+        // Update control button states
+        if (this.heatmapControl) {
+            const buttons = this.heatmapControl.querySelectorAll('.heatmap-filter-btn');
+            buttons.forEach((btn) => {
+                const btnElement = btn;
+                const btnFilter = btnElement.dataset.filter;
+                if (btnFilter === filter) {
+                    btnElement.classList.add('active');
+                }
+                else {
+                    btnElement.classList.remove('active');
+                }
+            });
+        }
+        // Announce filter change
+        const filterLabel = filter === 'all' ? 'all species' : filter === 'fauna' ? 'fauna only' : 'flora only';
+        this.announceToScreenReader(`Heatmap filter changed to ${filterLabel}.`);
+    },
+    createHeatmapControl() {
+        if (!this.map)
+            return;
+        const self = this;
+        const HeatmapControl = L.Control.extend({
+            options: {
+                position: 'topright'
+            },
+            onAdd() {
+                const container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-heatmap');
+                container.innerHTML = `
+                    <div class="heatmap-control-content">
+                        <div class="heatmap-control-title">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+                            </svg>
+                            <span>Heatmap</span>
+                        </div>
+                        <div class="heatmap-filter-buttons">
+                            <button class="heatmap-filter-btn active" data-filter="all" title="Show all species">All</button>
+                            <button class="heatmap-filter-btn" data-filter="fauna" title="Show fauna only">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M4.5 11c1.38 0 2.5-1.12 2.5-2.5S5.88 6 4.5 6 2 7.12 2 8.5 3.12 11 4.5 11zm9-2c1.38 0 2.5-1.12 2.5-2.5S14.88 4 13.5 4 11 5.12 11 6.5 12.12 9 13.5 9zm0 2c-1.38 0-2.5 1.12-2.5 2.5s1.12 2.5 2.5 2.5 2.5-1.12 2.5-2.5-1.12-2.5-2.5-2.5zm-9-2c-1.38 0-2.5 1.12-2.5 2.5s1.12 2.5 2.5 2.5 2.5-1.12 2.5-2.5S5.88 9 4.5 9zm0 7c1.38 0 2.5-1.12 2.5-2.5S5.88 11 4.5 11 2 12.12 2 13.5 3.12 16 4.5 16zm9 0c1.38 0 2.5-1.12 2.5-2.5s-1.12-2.5-2.5-2.5-2.5 1.12-2.5 2.5 1.12 2.5 2.5 2.5z"/>
+                                </svg>
+                            </button>
+                            <button class="heatmap-filter-btn" data-filter="flora" title="Show flora only">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M12 22c4.97 0 9-4.03 9-9-4.97 0-9 4.03-9 9zM5.6 10.25c0 1.38 1.12 2.5 2.5 2.5.53 0 1.01-.16 1.42-.44l-.02.19c0 1.38 1.12 2.5 2.5 2.5s2.5-1.12 2.5-2.5l-.02-.19c.4.28.89.44 1.42.44 1.38 0 2.5-1.12 2.5-2.5 0-1-.59-1.85-1.43-2.25.84-.4 1.43-1.25 1.43-2.25 0-1.38-1.12-2.5-2.5-2.5-.53 0-1.01.16-1.42.44l.02-.19C14.5 4.12 13.38 3 12 3s-2.5 1.12-2.5 2.5l.02.19c-.4-.28-.89-.44-1.42-.44-1.38 0-2.5 1.12-2.5 2.5 0 1 .59 1.85 1.43 2.25-.84.4-1.43 1.25-1.43 2.25zM12 5.5c1.38 0 2.5 1.12 2.5 2.5s-1.12 2.5-2.5 2.5S9.5 9.38 9.5 8s1.12-2.5 2.5-2.5zM3 13c0 4.97 4.03 9 9 9 0-4.97-4.03-9-9-9z"/>
+                                </svg>
+                            </button>
+                        </div>
+                        <button class="heatmap-close-btn" title="Close heatmap">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+                            </svg>
+                        </button>
+                    </div>
+                `;
+                L.DomEvent.disableClickPropagation(container);
+                // Handle filter button clicks
+                container.querySelectorAll('.heatmap-filter-btn').forEach((btn) => {
+                    L.DomEvent.on(btn, 'click', function (e) {
+                        L.DomEvent.preventDefault(e);
+                        const filter = btn.dataset.filter;
+                        if (filter) {
+                            self.setHeatmapFilter(filter);
+                        }
+                    });
+                });
+                // Handle close button click
+                const closeBtn = container.querySelector('.heatmap-close-btn');
+                if (closeBtn) {
+                    L.DomEvent.on(closeBtn, 'click', function (e) {
+                        L.DomEvent.preventDefault(e);
+                        self.hideHeatmap();
+                        self.dotNetHelper?.invokeMethodAsync('OnHeatmapClosed');
+                    });
+                }
+                self.heatmapControl = container;
+                return container;
+            }
+        });
+        new HeatmapControl().addTo(this.map);
+    },
+    updateHeatmapLayer() {
+        if (!this.map)
+            return;
+        // Remove existing heatmap layer
+        if (this.heatmapLayer) {
+            this.map.removeLayer(this.heatmapLayer);
+            this.heatmapLayer = null;
+        }
+        // Filter data based on current filter
+        let filteredData = this.heatmapData;
+        if (this.heatmapFilter === 'fauna') {
+            filteredData = this.heatmapData.filter(p => p.isFauna);
+        }
+        else if (this.heatmapFilter === 'flora') {
+            filteredData = this.heatmapData.filter(p => !p.isFauna);
+        }
+        if (filteredData.length === 0)
+            return;
+        // Convert to heatmap format [lat, lng, intensity]
+        const heatData = filteredData.map(p => [
+            p.latitude,
+            p.longitude,
+            p.intensity
+        ]);
+        // Create heatmap layer using Leaflet.heat
+        // @ts-ignore - L.heatLayer is provided by leaflet.heat plugin
+        this.heatmapLayer = L.heatLayer(heatData, {
+            radius: 25,
+            blur: 15,
+            maxZoom: 17,
+            max: 1.0,
+            gradient: {
+                0.0: '#3b82f6', // blue (low)
+                0.25: '#22c55e', // green
+                0.5: '#eab308', // yellow (medium)
+                0.75: '#f97316', // orange
+                1.0: '#ef4444' // red (high)
+            }
+        }).addTo(this.map);
     }
 };
 // ============================================================================

--- a/src/FaunaFinder.Server/wwwroot/js/leafletInterop.ts
+++ b/src/FaunaFinder.Server/wwwroot/js/leafletInterop.ts
@@ -92,6 +92,21 @@ interface LayerStyle {
 }
 
 /**
+ * A heatmap data point
+ */
+interface HeatmapPoint {
+    latitude: number;
+    longitude: number;
+    intensity: number;
+    isFauna: boolean;
+}
+
+/**
+ * Heatmap filter options
+ */
+type HeatmapFilter = 'all' | 'fauna' | 'flora';
+
+/**
  * Location error message types
  */
 type LocationErrorType =
@@ -157,6 +172,10 @@ interface LeafletInterop {
     drawPolygonPoints: L.LatLng[];
     drawPolygonMarkers: L.CircleMarker[];
     drawPolygonPreviewLine: L.Polyline | null;
+    heatmapLayer: L.Layer | null;
+    heatmapData: HeatmapPoint[];
+    heatmapFilter: HeatmapFilter;
+    heatmapControl: HTMLElement | null;
 
     setApiBaseUrl(url: string): void;
     initMap(dotNetHelper: DotNetHelper, apiBaseUrl?: string): void;
@@ -198,6 +217,11 @@ interface LeafletInterop {
     clearDrawnPolygon(): void;
     updateDrawingPolygon(): void;
     finishPolygon(): void;
+    showHeatmap(points: HeatmapPoint[]): void;
+    hideHeatmap(): void;
+    setHeatmapFilter(filter: HeatmapFilter): void;
+    createHeatmapControl(): void;
+    updateHeatmapLayer(): void;
 }
 
 // ============================================================================
@@ -229,6 +253,10 @@ window.leafletInterop = {
     drawPolygonPoints: [],
     drawPolygonMarkers: [],
     drawPolygonPreviewLine: null,
+    heatmapLayer: null,
+    heatmapData: [],
+    heatmapFilter: 'all',
+    heatmapControl: null,
     lightTileUrl: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
     darkTileUrl: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
     lightTheme: {
@@ -1338,6 +1366,188 @@ window.leafletInterop = {
 
         // Clear points
         this.drawPolygonPoints = [];
+    },
+
+    showHeatmap(points: HeatmapPoint[]): void {
+        if (!this.map) return;
+
+        // Store the full heatmap data
+        this.heatmapData = points;
+
+        // Create heatmap control if it doesn't exist
+        if (!this.heatmapControl) {
+            this.createHeatmapControl();
+        }
+
+        // Update the heatmap layer with filtered data
+        this.updateHeatmapLayer();
+
+        // Show the heatmap control
+        if (this.heatmapControl) {
+            this.heatmapControl.style.display = '';
+        }
+
+        // Announce to screen readers
+        this.announceToScreenReader(`Heatmap enabled showing ${points.length} species locations.`);
+    },
+
+    hideHeatmap(): void {
+        if (!this.map) return;
+
+        // Remove heatmap layer
+        if (this.heatmapLayer) {
+            this.map.removeLayer(this.heatmapLayer);
+            this.heatmapLayer = null;
+        }
+
+        // Clear data
+        this.heatmapData = [];
+
+        // Hide the heatmap control
+        if (this.heatmapControl) {
+            this.heatmapControl.style.display = 'none';
+        }
+
+        // Announce to screen readers
+        this.announceToScreenReader('Heatmap disabled.');
+    },
+
+    setHeatmapFilter(filter: HeatmapFilter): void {
+        this.heatmapFilter = filter;
+        this.updateHeatmapLayer();
+
+        // Update control button states
+        if (this.heatmapControl) {
+            const buttons = this.heatmapControl.querySelectorAll('.heatmap-filter-btn');
+            buttons.forEach((btn: Element) => {
+                const btnElement = btn as HTMLElement;
+                const btnFilter = btnElement.dataset.filter;
+                if (btnFilter === filter) {
+                    btnElement.classList.add('active');
+                } else {
+                    btnElement.classList.remove('active');
+                }
+            });
+        }
+
+        // Announce filter change
+        const filterLabel = filter === 'all' ? 'all species' : filter === 'fauna' ? 'fauna only' : 'flora only';
+        this.announceToScreenReader(`Heatmap filter changed to ${filterLabel}.`);
+    },
+
+    createHeatmapControl(): void {
+        if (!this.map) return;
+
+        const self = this;
+
+        const HeatmapControl = L.Control.extend({
+            options: {
+                position: 'topright' as L.ControlPosition
+            },
+
+            onAdd(): HTMLElement {
+                const container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-heatmap');
+                container.innerHTML = `
+                    <div class="heatmap-control-content">
+                        <div class="heatmap-control-title">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+                            </svg>
+                            <span>Heatmap</span>
+                        </div>
+                        <div class="heatmap-filter-buttons">
+                            <button class="heatmap-filter-btn active" data-filter="all" title="Show all species">All</button>
+                            <button class="heatmap-filter-btn" data-filter="fauna" title="Show fauna only">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M4.5 11c1.38 0 2.5-1.12 2.5-2.5S5.88 6 4.5 6 2 7.12 2 8.5 3.12 11 4.5 11zm9-2c1.38 0 2.5-1.12 2.5-2.5S14.88 4 13.5 4 11 5.12 11 6.5 12.12 9 13.5 9zm0 2c-1.38 0-2.5 1.12-2.5 2.5s1.12 2.5 2.5 2.5 2.5-1.12 2.5-2.5-1.12-2.5-2.5-2.5zm-9-2c-1.38 0-2.5 1.12-2.5 2.5s1.12 2.5 2.5 2.5 2.5-1.12 2.5-2.5S5.88 9 4.5 9zm0 7c1.38 0 2.5-1.12 2.5-2.5S5.88 11 4.5 11 2 12.12 2 13.5 3.12 16 4.5 16zm9 0c1.38 0 2.5-1.12 2.5-2.5s-1.12-2.5-2.5-2.5-2.5 1.12-2.5 2.5 1.12 2.5 2.5 2.5z"/>
+                                </svg>
+                            </button>
+                            <button class="heatmap-filter-btn" data-filter="flora" title="Show flora only">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M12 22c4.97 0 9-4.03 9-9-4.97 0-9 4.03-9 9zM5.6 10.25c0 1.38 1.12 2.5 2.5 2.5.53 0 1.01-.16 1.42-.44l-.02.19c0 1.38 1.12 2.5 2.5 2.5s2.5-1.12 2.5-2.5l-.02-.19c.4.28.89.44 1.42.44 1.38 0 2.5-1.12 2.5-2.5 0-1-.59-1.85-1.43-2.25.84-.4 1.43-1.25 1.43-2.25 0-1.38-1.12-2.5-2.5-2.5-.53 0-1.01.16-1.42.44l.02-.19C14.5 4.12 13.38 3 12 3s-2.5 1.12-2.5 2.5l.02.19c-.4-.28-.89-.44-1.42-.44-1.38 0-2.5 1.12-2.5 2.5 0 1 .59 1.85 1.43 2.25-.84.4-1.43 1.25-1.43 2.25zM12 5.5c1.38 0 2.5 1.12 2.5 2.5s-1.12 2.5-2.5 2.5S9.5 9.38 9.5 8s1.12-2.5 2.5-2.5zM3 13c0 4.97 4.03 9 9 9 0-4.97-4.03-9-9-9z"/>
+                                </svg>
+                            </button>
+                        </div>
+                        <button class="heatmap-close-btn" title="Close heatmap">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+                            </svg>
+                        </button>
+                    </div>
+                `;
+
+                L.DomEvent.disableClickPropagation(container);
+
+                // Handle filter button clicks
+                container.querySelectorAll('.heatmap-filter-btn').forEach((btn: Element) => {
+                    L.DomEvent.on(btn as HTMLElement, 'click', function(e) {
+                        L.DomEvent.preventDefault(e);
+                        const filter = (btn as HTMLElement).dataset.filter as HeatmapFilter;
+                        if (filter) {
+                            self.setHeatmapFilter(filter);
+                        }
+                    });
+                });
+
+                // Handle close button click
+                const closeBtn = container.querySelector('.heatmap-close-btn');
+                if (closeBtn) {
+                    L.DomEvent.on(closeBtn as HTMLElement, 'click', function(e) {
+                        L.DomEvent.preventDefault(e);
+                        self.hideHeatmap();
+                        self.dotNetHelper?.invokeMethodAsync('OnHeatmapClosed');
+                    });
+                }
+
+                self.heatmapControl = container;
+                return container;
+            }
+        });
+
+        new HeatmapControl().addTo(this.map);
+    },
+
+    updateHeatmapLayer(): void {
+        if (!this.map) return;
+
+        // Remove existing heatmap layer
+        if (this.heatmapLayer) {
+            this.map.removeLayer(this.heatmapLayer);
+            this.heatmapLayer = null;
+        }
+
+        // Filter data based on current filter
+        let filteredData = this.heatmapData;
+        if (this.heatmapFilter === 'fauna') {
+            filteredData = this.heatmapData.filter(p => p.isFauna);
+        } else if (this.heatmapFilter === 'flora') {
+            filteredData = this.heatmapData.filter(p => !p.isFauna);
+        }
+
+        if (filteredData.length === 0) return;
+
+        // Convert to heatmap format [lat, lng, intensity]
+        const heatData: [number, number, number][] = filteredData.map(p => [
+            p.latitude,
+            p.longitude,
+            p.intensity
+        ]);
+
+        // Create heatmap layer using Leaflet.heat
+        // @ts-ignore - L.heatLayer is provided by leaflet.heat plugin
+        this.heatmapLayer = L.heatLayer(heatData, {
+            radius: 25,
+            blur: 15,
+            maxZoom: 17,
+            max: 1.0,
+            gradient: {
+                0.0: '#3b82f6', // blue (low)
+                0.25: '#22c55e', // green
+                0.5: '#eab308', // yellow (medium)
+                0.75: '#f97316', // orange
+                1.0: '#ef4444'  // red (high)
+            }
+        }).addTo(this.map);
     }
 };
 

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/ISpeciesHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/ISpeciesHttpClient.cs
@@ -40,4 +40,8 @@ public interface ISpeciesHttpClient
     Task<IReadOnlyList<SpeciesCategoryDto>> GetCategoriesAsync(
         CancellationToken cancellationToken = default
     );
+
+    Task<IReadOnlyList<HeatmapPointDto>> GetHeatmapDataAsync(
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/SpeciesHttpClient.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Application.Client/SpeciesHttpClient.cs
@@ -123,4 +123,15 @@ public sealed class SpeciesHttpClient(HttpClient httpClient) : ISpeciesHttpClien
         );
         return result ?? [];
     }
+
+    public async Task<IReadOnlyList<HeatmapPointDto>> GetHeatmapDataAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        var result = await httpClient.GetFromJsonAsync<IReadOnlyList<HeatmapPointDto>>(
+            "api/species/heatmap",
+            cancellationToken
+        );
+        return result ?? [];
+    }
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Dtos/HeatmapPointDto.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.Contracts/Dtos/HeatmapPointDto.cs
@@ -1,0 +1,8 @@
+namespace FaunaFinder.Wildlife.Contracts.Dtos;
+
+public sealed record HeatmapPointDto(
+    double Latitude,
+    double Longitude,
+    double Intensity,
+    bool IsFauna
+);

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Interfaces/ISpeciesRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Interfaces/ISpeciesRepository.cs
@@ -57,4 +57,14 @@ public interface ISpeciesRepository
     Task<IReadOnlyList<SpeciesCategoryDto>> GetAllCategoriesAsync(
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Gets all species locations for generating a heatmap visualization.
+    /// Each location point includes coordinates and whether the species is fauna or flora.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of heatmap points with intensity values.</returns>
+    Task<IReadOnlyList<HeatmapPointDto>> GetHeatmapDataAsync(
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
+++ b/src/Features/Wildlife/FaunaFinder.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
@@ -424,4 +424,24 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
             .Select(c => new SpeciesCategoryDto(c.Id, c.Code, c.Name.ToList()))
             .ToListAsync(cancellationToken);
     }
+
+    public async Task<IReadOnlyList<HeatmapPointDto>> GetHeatmapDataAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        // Get all species locations with fauna/flora classification
+        // Intensity is set to 1.0 for now - can be adjusted based on species count at location
+        return await context
+            .Species.AsNoTracking()
+            .Where(s => s.Locations.Any())
+            .SelectMany(s => s.Locations.Select(l => new HeatmapPointDto(
+                l.Latitude,
+                l.Longitude,
+                1.0,
+                s.IsFauna
+            )))
+            .ToListAsync(cancellationToken);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds heatmap layer visualization to show species location density on the map
- Implements toggle button (FAB) to enable/disable heatmap on both desktop and mobile
- Provides filter options to view all species, fauna only, or flora only
- Uses color gradient: blue/green (low density) → yellow/orange (medium) → red (high density)

## Changes
- **Backend**: New `/api/species/heatmap` endpoint returning all species locations with fauna/flora classification
- **Frontend**: Heatmap toggle FAB, control panel with filter buttons, Leaflet.heat integration
- **Localization**: EN/ES strings for heatmap labels

## Test plan
- [ ] Toggle heatmap on/off using the FAB button
- [ ] Verify heatmap displays species location density
- [ ] Test filter options (All, Fauna, Flora)
- [ ] Test on mobile breakpoint
- [ ] Verify heatmap works in both light and dark mode

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)